### PR TITLE
Fix ebbr rst link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ can look at the source text directly here:
 GitHub does a good job of rendering the reStructuredText markup into
 something readable.
 
-.. _`EBBR Draft Text`: source/ebbr.rst
+.. _`EBBR Draft Text`: source/index.rst
 
 Build Instructions
 ==================


### PR DESCRIPTION
Commit 31a07c9cb8fc ("Rename ebbr.rst to index.rst for html generation")
changed the file name of the ebbr specification rst file, but missed to
update the README file that points to it.

Adapt the README accordingly as well.

Fixes: 31a07c9cb8fc ("Rename ebbr.rst to index.rst for html generation")
Signed-off-by: Alexander Graf <agraf@suse.de>