### PR TITLE
Fix sphinx-doc link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Build Instructions
 Requirements
 ^^^^^^^^^^^^
 
-* Sphinx version 1.5 or later: http://sphinx-doc.org/contents.html
+* Sphinx version 1.5 or later: http://sphinx-doc.org/en/master/contents.html
 * LaTeX (and pdflatex, and various LaTeX packages)
 
 On Debian and Ubuntu


### PR DESCRIPTION
The previous link was pointing to a 404 page: http://www.sphinx-doc.org/contents.html
I wasn't sure whether to keep the `www` part, but it seems this is the canonical URL.