### PR TITLE
Update link to OP-TEE secure storage

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -251,4 +251,4 @@ that GetVariable() and GetNextVeriableName() can behave as specified.
    Regardless, EBBR compliance does not require SetVariable() support
    during runtime services.
 
-   https://github.com/OP-TEE/optee_os/blob/master/documentation/secure_storage.md
+   https://optee.readthedocs.io/en/latest/architecture/secure_storage.html


### PR DESCRIPTION
I was reading the 1.0.1 version just released by Grant and I noticed that the URL to the OP-TEE secure storage points to the old documentation location. This PR will update the URL to the correct location at `optee.readthedocs.io`.

// Joakim