### PR TITLE
GetMemoryMap(), handling of no-map DT property

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -74,6 +74,10 @@ that virtual addresses must equal physical addresses.
 
 The default RAM allocated attribute must be EFI_MEMORY_WB.
 
+Reserved memory with property no-map [RESMEM]_ in the /reserved-memory
+device-tree node shall not be included in the memory map returned by
+GetMemoryMap().
+
 Configuration Tables
 --------------------
 

--- a/source/references.rst
+++ b/source/references.rst
@@ -16,6 +16,10 @@
    <https://static.docs.arm.com/den0022/c/DEN0022C_Power_State_Coordination_Interface.pdf>`_
    30 January 2015, `Arm Limited <http://arm.com>`_
 
+.. [RESMEM] `Reserved memory regions
+   <https://www.kernel.org/doc/Documentation/devicetree/bindings/reserved-memory/reserved-memory.txt>`_,
+   21 July 2020, Linux kernel
+
 .. [SBBR] `Arm Server Base Boot Requirements specification Issue B (v1.0)
    <https://static.docs.arm.com/den0044/b/DEN0044B_Server_Base_Boot_Requirements.pdf>`_
    8 March 2016, `Arm Limited <http://arm.com>`_


### PR DESCRIPTION
Closes: #52

The no-map property of the /reserved-memory DT node is used by Linux to
signal that a memory region shall not be mapped and that speculative access
shall not be permitted.

The memory map returned by GetMemoryMap() does not have a flag
corresponding to no-map. So the closest thing we can do is not to include
no-map reserved memory into the map returned by GetMemoryMap().

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>