### PR TITLE
GetMemoryMap(), handling of no-map DT property

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -74,6 +74,19 @@ that virtual addresses must equal physical addresses.
 
 The default RAM allocated attribute must be EFI_MEMORY_WB.
 
+In the device tree reserved memory is modelled as a /reserved-memory nodes
+[RESMEM]_. The reserved-memory node MAY carry either the no-map or the resue
+property. It MUST NOT carry both properties as this would be contradictary.
+
+A 'no-map' reserved memory node describes memory that the UEFI payload MUST NOT
+access. It MUST be modelled as a EfiReservedMemoryType entry in the memory map.
+
+A reserved memory without the 'no-map' describes memory that MAY be used by the
+UEFI payload after ExitBootServices(). It MUST be modelled as a memory map entry
+that can only be used by the UEFI payload after ExitBootServices(). It
+is recommended to use EfiBootServicesData. The node MUST NOT be modelled as
+EfiReservedMemoryType and NOT as EfiConventionalMemory.
+
 Configuration Tables
 --------------------
 

--- a/source/references.rst
+++ b/source/references.rst
@@ -16,6 +16,10 @@
    <https://static.docs.arm.com/den0022/c/DEN0022C_Power_State_Coordination_Interface.pdf>`_
    30 January 2015, `Arm Limited <http://arm.com>`_
 
+.. [RESMEM] `Reserved memory regions
+   <https://www.kernel.org/doc/Documentation/devicetree/bindings/reserved-memory/reserved-memory.txt>`_,
+   21 July 2020, Linux kernel
+
 .. [SBBR] `Arm Server Base Boot Requirements specification Issue B (v1.0)
    <https://static.docs.arm.com/den0044/b/DEN0044B_Server_Base_Boot_Requirements.pdf>`_
    8 March 2016, `Arm Limited <http://arm.com>`_


### PR DESCRIPTION
Closes: #52

The no-map property of the /reserved-memory device tree nodes is used to
signal that a memory region shall not be accessed by the operating system,
even not via speculative access.

/reserved-memory nodes without the no-map property describe memory that
have special usage by the operating system.

This difference has to be reflected in the memory map returned by
GetMemoryMap().

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>