### PR TITLE
Uefi requirement updates

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -14,8 +14,167 @@ This document uses version 2.8 Errata A of the UEFI specification [UEFI]_.
 UEFI Compliance
 ===============
 
-EBBR compliant platforms shall conform to the requirements in [UEFI]_ § 2.6,
-except where explicit exemptions are provided by this document.
+EBBR compliant platform shall conform to a subset of the [UEFI]_ spec as listed
+in this section.
+Normally, UEFI compliance would require full compliance with all items listed
+in UEFI § 2.6.
+However, the EBBR target market has a reduced set of requirements,
+and so some UEFI features are omitted as unnecessary.
+
+Required Elements
+-----------------
+
+This section replaces the list of required elements in [UEFI]_ § 2.6.1.
+All of the following UEFI elements are required for EBBR compliance.
+
+.. list-table:: UEFI Required Elements
+   :widths: 50 50
+   :header-rows: 1
+
+   * - Element
+     - Requirement
+   * - `EFI_SYSTEM_TABLE`
+     - The system table is required to provide required to access UEFI Boot Services,
+       UEFI Runtime Services, consoles, and other firmware, vendor and platform
+       information.
+   * - `EFI_BOOT_SERVICES`
+     - All functions defined as boot services must exist.
+       Methods for unsupported or unimplemented behaviour must return
+       an appropriate error code.
+   * - `EFI_RUNTIME_SERVICES`
+     - All functions defined as runtime services must exist.
+       Methods for unsupported or unimplemented behaviour must return
+       an appropriate error code.
+   * - `EFI_LOADED_IMAGE_PROTOCOL`
+     - Must be installed for each loaded image
+   * - `EFI_LOADED_IMAGE_DEVICE_PATH_PROTOCOL`
+     - Must be installed for each loaded image
+   * - `EFI_DEVICE_PATH_PROTOCOL`
+     - An `EFI_DEVICE_PATH_PROTOCOL` must be installed onto all device
+       handles provided by the firmware.
+   * - `EFI_DEVICE_PATH_UTILITIES_PROTOCOL`
+     - Interface for creating and manipulating UEFI device paths
+
+.. list-table:: Notable omissions from UEFI § 2.6.1
+   :header-rows: 1
+
+   * - Element
+     - Note
+   * - `EFI_DECOMPRESS_PROTOCOL`
+     - Native EFI decompression is rarely used and therefore not required.
+
+Required Platform Specific Elements
+-----------------------------------
+
+This section replaces the list of required elements in [UEFI]_ § 2.6.2.
+All of the following UEFI elements are required for EBBR compliance.
+
+.. list-table:: UEFI Platform-Specific Required Elements
+   :widths: 50 50
+   :header-rows: 1
+
+   * - Element
+     - Description
+   * - Console devices
+     - The platform must have at least one console device
+   * - `EFI_SIMPLE_TEXT_INPUT_PROTOCOL`
+     - Needed for console input
+   * - `EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL`
+     - Needed for console input
+   * - `EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL`
+     - Needed for console output
+   * - `EFI_DEVICE_PATH_TO_TEXT_PROTOCOL`
+     - Needed for console output
+   * - `EFI_HII_STRING_PROTOCOL`
+     - Required by EFI shell and for compliance testing
+   * - `EFI_HII_DATABASE_PROTOCOL`
+     - Required by EFI shell and for compliance testing
+   * - `EFI_UNICODE_COLLATION2_PROTOCOL`
+     - Required by EFI shell and for compliance testing
+   * - `EFI_BLOCK_IO_PROTOCOL`
+     - Required for block device access
+   * - `EFI_SIMPLE_FILE_SYSTEM_PROTOCOL`
+     - Required if booting from block device is supported
+   * - `EFI_RNG_PROTOCOL`
+     - Required if platform has a hardware entropy source
+   * - Network booting
+     - If the platform supports network booting
+       then `EFI_SIMPLE_NETWORK_PROTOCOL` must be implemented.
+
+The following table is a list of notable deviations from UEFI § 2.6.2.
+Many of these deviations are because the EBBR use cases do not require
+interface specific UEFI protocols, and so they have been made optional.
+
+.. list-table:: Notable Deviations from UEFI § 2.6.2
+   :widths: 50 50
+   :header-rows: 1
+
+   * - Element
+     - Description of deviation
+   * - `EFI_HII_CONFIG_ACCESS_PROTOCOL`
+     - UEFI requires this for console devices, but it is rarely necessary in practice.
+       Therefore this protocol is not required.
+   * - `EFI_HII_CONFIG_ROUTING_PROTOCOL`
+     - UEFI requires this for console devices, but it is rarely necessary in practice.
+       Therefore this protocol is not required.
+   * - Graphical console
+     - Platforms with a graphical device are not required to expose it as a graphical console.
+   * - `EFI_DISK_IO_PROTOCOL`
+     - Rarely used interface that isn't required for EBBR use cases
+   * - `EFI_PXE_BASE_CODE_PROTOCOL`
+     - Booting via the Preboot Execution Environment (PXE) is insecure.
+       Loading via PXE is typically executed before launching the first UEFI application.
+   * - Network protocols
+     - A full implementation of the UEFI general purpose networking ABIs is not required,
+       including `EFI_NETWORK_INTERFACE_IDENTIFIER_PROTOCOL`, `EFI_MANAGED_NETWORK_PROTOCOL`,
+       `EFI_*_SERVICE_BINDING_PROTOCOL`, or any of the IPv4 or IPv6 protocols.
+   * - Byte stream device support (UART)
+     - UEFI protocols not required
+   * - PCI bus support
+     - UEFI protocols not required
+   * - USB bus support
+     - UEFI protocols not required
+   * - NVMe pass through support
+     - UEFI protocols not required
+   * - SCSI pass through support
+     - UEFI protocols not required
+   * - SCSI pass through support
+     - UEFI protocols not required
+   * - `EFI_DRIVER_FAMILY_OVERRIDE_PROTOCOL`
+     - Not required
+   * - Option ROM support
+     - In many EBBR use cases there is no requirement to generically support
+       any PCIe add in card at the firmware level.
+       When PCIe devices are used, drivers for the device are often built into
+       the firmware itself rather than loaded as option ROMs.
+       For this reason EBBR implementations are not required to support option
+       ROM loading.
+
+Required Global Variables
+-------------------------
+
+EBBR compliant platforms are required to support the following Global
+Variables as found in [UEFI]_ § 3.3.
+
+.. list-table:: Required UEFI Variables
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Variable Name
+     - Description
+   * - `Boot####`
+     - A boot load option. #### is a numerical hex value
+   * - `BootCurrent`
+     - The boot option that was selected for the current boot
+   * - `BootNext`
+     - The boot option that will be used for the next boot only
+   * - `BootOrder`
+     - An ordered list of boot options.
+       Firmware will attempt each Boot#### entry in this order
+   * - `OsIndications`
+     - Method for OS to request features from firmware
+   * - `OsIndicationsSupported`
+     - Variable for firmware to indicate which features can be enabled
 
 Block device partitioning
 -------------------------


### PR DESCRIPTION
This PR adds details to what parts of the UEFI spec EBBR requires, overriding UEFI section 2.6. Please review and comment.