### PR TITLE
README.rst: Python 2 is long time gone

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,31 +41,28 @@ On Debian and Ubuntu
 ^^^^^^^^^^^^^^^^^^^^
 ::
 
-  # apt-get install python-sphinx texlive texlive-latex-extra libalgorithm-diff-perl \
+  # apt-get install python3-sphinx texlive texlive-latex-extra libalgorithm-diff-perl \
                     texlive-humanities texlive-generic-recommended texlive-generic-extra \
                     latexmk
 
 If the version of python-sphinx installed is too old, then an additional
 new version can be installed with the Python package installer::
 
-  $ apt-get install python-pip
-  $ pip install --user --upgrade Sphinx
+  $ apt-get install python3-pip
+  $ pip3 install --user --upgrade Sphinx
   $ export SPHINXBUILD=~/.local/bin/sphinx-build
 
-Export SPHINXBUILD (see above) if Sphinx was installed with pip --user, then follow Make commands below
+Export SPHINXBUILD (see above) if Sphinx was installed with pip3 --user, then follow Make commands below.
 
 On Fedora
 ^^^^^^^^^
 
 ::
 
-  # dnf install python2-sphinx texlive texlive-capt-of texlive-draftwatermark \
+  # dnf install python3-sphinx texlive texlive-capt-of texlive-draftwatermark \
                 texlive-fncychap texlive-framed texlive-needspace \
                 texlive-tabulary texlive-titlesec texlive-upquote \
                 texlive-wrapfig
-
-It is also possible to use python3-sphinx; this requires
-SPHINXBUILD=sphinx-build-3 to be passed on the Make command line.
 
 On Mac OS X
 ^^^^^^^^^^^


### PR DESCRIPTION
Updated to use Python 3 versions of Sphinx.

Checked on Fedora 33 and Debian 'buster'.