### PR TITLE
CONTRIBUTING: let wording follow branching

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,7 +1,7 @@
 Contributing
 ============
 
-Master copy of this project is hosted on GitHub:
+Main copy of this project is hosted on GitHub:
 https://github.com/ARM-software/ebbr
 
 Anyone may contribute to the EBBR project.


### PR DESCRIPTION
Main branch of EBBR code is called 'main' so let follow it.

Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>