### PR TITLE
chapter1: remove reference to v1.0

### DIFF
--- a/source/chapter1-about.rst
+++ b/source/chapter1-about.rst
@@ -120,7 +120,7 @@ The following guiding principles are used while developing the EBBR specificatio
 
 - Plan to evolve over time
 
-  The v1.0 release of EBBR is firmly targeted at existing platforms so that
+  The current release of EBBR is firmly targeted at existing platforms so that
   gaining EBBR compliance may require a firmware update, but will not require
   hardware changes for the majority of platforms.
 


### PR DESCRIPTION
We describe a design principle applicable to the current release (v2.0) and
not only to v1.0.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>