### PR TITLE
chapter2: update UEFI version to 2.9.

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -9,7 +9,8 @@ platforms.
 
 UEFI Version
 ============
-This document uses version 2.8 Errata A of the UEFI specification [UEFI]_.
+
+This document is based upon version 2.9 of the UEFI specification [UEFI]_.
 
 UEFI Compliance
 ===============

--- a/source/references.rst
+++ b/source/references.rst
@@ -26,6 +26,6 @@
    <https://developer.arm.com/documentation/den0044/f>`_
    6 Oct 2020, `Arm Limited <http://arm.com>`_
 
-.. [UEFI] `Unified Extensable Firmware Interface Specification v2.8 Errata A
-   <https://uefi.org/sites/default/files/resources/UEFI_Spec_2_8_A_Feb14.pdf>`_,
+.. [UEFI] `Unified Extensable Firmware Interface Specification v2.9
+   <https://uefi.org/sites/default/files/resources/UEFI_Spec_2_9_2021_03_18.pdf`_,
    February 2020, `UEFI Forum <http://www.uefi.org>`_


### PR DESCRIPTION
The current UEFI specification version is 2.9.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>