### PR TITLE
Require conformance profile table for EBBRv2 systems

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -284,6 +284,9 @@ Configuration Tables
 A UEFI system that complies with this specification may provide additional
 tables via the EFI Configuration Table.
 
+System Configuration
+^^^^^^^^^^^^^^^^^^^^
+
 Compliant systems are required to provide one, but not both, of the following
 tables:
 
@@ -297,7 +300,7 @@ mechanism to select either ACPI or Devicetree,
 and must ensure only the selected interface is provided to the OS loader.
 
 Devicetree
-^^^^^^^^^^
+""""""""""
 
 If firmware provides a Devicetree system description then it must be provided
 in Flattened Devicetree Blob (DTB) format version 17 or higher as described in

--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -21,6 +21,7 @@ Normally, UEFI compliance would require full compliance with all items listed
 in UEFI § 2.6.
 However, the EBBR target market has a reduced set of requirements,
 and so some UEFI features are omitted as unnecessary.
+Systems that comply with EBBR version 2.0 are expected to publicize their compliance, as specified in `Conformance Profile`_.
 
 Required Elements
 -----------------
@@ -308,6 +309,16 @@ in Flattened Devicetree Blob (DTB) format version 17 or higher as described in
 The DTB must be contained in memory of type EfiACPIReclaimMemory.
 EfiACPIReclaimMemory was chosen to match the recommendation for ACPI
 tables which fulfill the same task as the DTB.
+
+Conformance Profile
+^^^^^^^^^^^^^^^^^^^
+
+.. _Conformance Profile:
+
+A system compliant with EBBR version 2.0 is should provide an
+EFI_CONFORMANCE_PROFILE_TABLE containing at least the
+EFI_CONFORMANCE_PROFILES_EBBR_2_0_GUID profile (as
+defined in [UEFI]_, sub-section EFI_CONFORMANCE_PROFILE_TABLE).
 
 UEFI Secure Boot (Optional)
 ---------------------------


### PR DESCRIPTION
This PR suggests EBBRv2 systems to publicize their compliance by having the EFI_CONFORMANCE_PROFILE_TABLE with an EFI_CONFORMANCE_PROFILE_EBBR_2_0_GUID entry.

The conformance profile table has been submitted as a code-first BZ ticket: https://bugzilla.tianocore.org/show_bug.cgi?id=3591
The ticket has been approved. The contents will be integrated into the next UEFI spec release.

This PR must also:
- change the UEFI spec reference to 2.9+. 
- Amend the text in Section 2.1 to mention UEFI 2.9+, instead of the current 2.9.