### PR TITLE
Revive ESRT requirement and require authenticated capsules in FMP format

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -465,8 +465,9 @@ Being able to update firmware to address security issues is a key feature of sec
 EBBR platforms are required to implement either an in-band or an out-of-band firmware update mechanism.
 
 If firmware update is performed in-band (firmware on the application processor updates itself),
-then the firmware shall implement the `UpdateCapsule()` runtime service and accept updates in the
-"Firmware Management Protocol Data Capsule Structure" format as described in [UEFI]_ § 23.3,
+then the firmware shall implement the `UpdateCapsule()` runtime service and accept only authenticated
+updates in the "Firmware Management Protocol Data Capsule Structure" format with
+`IMAGE_ATTRIBUTE_AUTHENTICATION_REQUIRED` set as described in [UEFI]_ § 23.3,
 "Delivering Capsules Containing Updates to Firmware Management Protocol.  [#FMPNote]_
 Firmware is also required to provide an EFI System Resource Table (ESRT). [UEFI]_ § 23.4
 Every firmware image that can be updated in-band must be described in the ESRT.

--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -467,13 +467,16 @@ EBBR platforms are required to implement either an in-band or an out-of-band fir
 If firmware update is performed in-band (firmware on the application processor updates itself),
 then the firmware shall implement the `UpdateCapsule()` runtime service and accept updates in the
 "Firmware Management Protocol Data Capsule Structure" format as described in [UEFI]_ § 23.3,
-"Delivering Capsules Containing Updates to Firmware Management Protocol."
+"Delivering Capsules Containing Updates to Firmware Management Protocol.  [#FMPNote]_
+Firmware is also required to provide an EFI System Resource Table (ESRT). [UEFI]_ § 23.4
+Every firmware image that can be updated in-band must be described in the ESRT.
 
 If firmware update is performed out-of-band (e.g., by an independent Baseboard
 Management Controller (BMC), or firmware is provided by a hypervisor),
 then the platform is not required to implement the `UpdateCapsule()` runtime service.
 
 `UpdateCapsule()` is only required before `ExitBootServices()` is called.
+
 
 .. [#OPTEESupplicant] It is worth noting that OP-TEE has a similar problem
    regarding secure storage.
@@ -485,3 +488,11 @@ then the platform is not required to implement the `UpdateCapsule()` runtime ser
    during runtime services.
 
    https://optee.readthedocs.io/en/latest/architecture/secure_storage.html
+
+.. [#FMPNote] The `UpdateCapsule()` runtime service is expected to be suitable
+   for use by generic firmware update services like fwupd and Windows Update.
+   Both fwupd and Windows Update read the ESRT table to determine what firmware
+   can be updated, and use an EFI helper application to call `UpdateCapsule()`
+   before `ExitBootServices()` is called.
+
+   https://fwupd.org/


### PR DESCRIPTION
I would like to propose reviving the ESRT requirement, please.
Upstream U-Boot supports the ESRT since v2021.07, which makes this new requirement realistic.

Also, require authenticated capsules in FMP format.

This is in preparation of Arm SystemReady IR 2.0.
