### PR TITLE
UEFI: GUID for EFI Conformance Profile Table

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -296,6 +296,18 @@ Systems that support both interfaces must provide a configuration
 mechanism to select either ACPI or Devicetree,
 and must ensure only the selected interface is provided to the OS loader.
 
+EFI Conformance Profile Table
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following GUID in the EFI Conformance Profile Table is used to indicate
+compliance to version 2.0 of the EBBR specification:
+
+.. code-block:: c
+
+    #define EFI_CONFORMANCE_PROFILE_EBBR_2_0_GUID
+    { 0xcce33c35, 0x74ac, 0x4087, \
+    { 0xbc, 0xe7, 0x8b, 0x29, 0xb0, 0x2e, 0xeb, 0x27 }}
+
 Devicetree
 ^^^^^^^^^^
 


### PR DESCRIPTION
Provide a GUID that can be used in the EFI Conformance Profile Table to
indicate conformance with the EBBR 2.0 specification.

Fixes: #95
Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>