### PR TITLE
Require RISCV_EFI_BOOT_PROTOCOL on RISC-V platforms

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -104,6 +104,8 @@ All of the following UEFI elements are required for EBBR compliance.
      - Required if the platform has a network device.
    * - HTTP Boot (UEFI § 24.7)
      - Required if the platform supports network booting
+   * - `RISCV_EFI_BOOT_PROTOCOL` [RVUEFI]_
+     - Required on RISC-V platforms
 
 The following table is a list of notable deviations from UEFI § 2.6.2.
 Many of these deviations are because the EBBR use cases do not require

--- a/source/index.rst
+++ b/source/index.rst
@@ -86,6 +86,8 @@ Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
        - Update PSCI version to issue D.b (v1.1)
        - Update BBR version to issue G (v2.0)
        - Fix typos and spelling
+   * - 22 Nov 2022
+       - Add RISCV_EFI_BOOT_PROTOCOL requirement
 
 .. toctree::
    :numbered:

--- a/source/references.rst
+++ b/source/references.rst
@@ -35,3 +35,5 @@
 .. [RVSBISPEC] `RISC-V Supervisor Binary Interface specification <https://github.com/riscv/riscv-sbi-doc>`_
 
 .. [RVHYPSPEC] `RISC-V ISA Hypervisor extension <https://github.com/riscv/riscv-isa-manual/blob/master/src/hypervisor.tex>`_
+
+.. [RVUEFI] `RISC-V UEFI Protocol Specification <https://github.com/riscv-non-isa/riscv-uefi/releases/download/1.0.0/RISCV_UEFI_PROTOCOL-spec.pdf>`_


### PR DESCRIPTION
The RISCV_EFI_BOOT_PROTOCOL protocol is needed to identify the booting hart on RISC-V platforms.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>