### PR TITLE
Refresh reference for RISC-V hypervisor extension

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -248,13 +248,13 @@ is available at OS load time.
 UEFI Boot at S mode
 ^^^^^^^^^^^^^^^^^^^
 
-Most systems are expected to boot UEFI at S mode as the hypervisor extension
-[RVHYPSPEC]_ is still in draft state.
+Most systems are expected to boot UEFI at S mode when the hypervisor extension
+is not enabled [RVPRIVSPEC]_.
 
 UEFI Boot at HS mode
 ^^^^^^^^^^^^^^^^^^^^
 
-Any platform with hypervisor extension enabled most likely to boot UEFI at HS mode,
+Any platform supporting the hypervisor extension enabled most likely will boot UEFI at HS mode,
 to allow for the installation of a hypervisor or a virtualization aware Operating System.
 
 UEFI Boot at VS mode

--- a/source/references.rst
+++ b/source/references.rst
@@ -35,6 +35,8 @@
 .. [RVSBISPEC] `RISC-V Supervisor Binary Interface specification
    <https://github.com/riscv-non-isa/riscv-sbi-doc>`_
 
-.. [RVHYPSPEC] `RISC-V ISA Hypervisor extension <https://github.com/riscv/riscv-isa-manual/blob/master/src/hypervisor.tex>`_
+.. [RVPRIVSPEC] `The RISC-V Instruction Set Manual Volume II: Privileged Architecture
+   <https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf>`_,
+   Version 20211203
 
 .. [RVUEFI] `RISC-V UEFI Protocol Specification <https://github.com/riscv-non-isa/riscv-uefi/releases/download/1.0.0/RISCV_UEFI_PROTOCOL-spec.pdf>`_


### PR DESCRIPTION
The RISC-V Hypervisor Extension is now defined as part of RISC-V Privileged Architecture specification. Update EBBR accordingly.

Fixes: #100
Signed-off-by: Vincent Stehlé <vincent.stehle@arm.com>
Cc: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>