### PR TITLE
Arm sections changes (was support Armv8-R AArch64)

### DIFF
--- a/source/chapter1-about.rst
+++ b/source/chapter1-about.rst
@@ -219,48 +219,54 @@ Architecture specific terms are listed a section for each architecture.
       within a device. In the context of storage, a single device may use
       logical units to provide multiple independent storage areas.
 
-AARCH32
--------
+Arm
+---
+
+Refer to the Arm Architecture Reference Manual for A-profile architecture
+[ArmARM]_.
 
 .. glossary::
 
    AArch32
-      Arm 32-bit architectures. AArch32 is a roll up term referring to all
-      32-bit versions of the Arm architecture starting at ARMv4.
+      The Arm 32-bit Execution state.
+      In this state, addresses are held in 32-bit registers, and instructions in
+      the base instruction sets use 32-bit registers for their processing.
+      This state supports the T32 and A32 instruction sets.
+      This is the execution state used by all pre-Armv8 architectures.
 
-AARCH64
--------
+   A32
+      The 32-bit length instruction set, known as Arm instruction set in
+      pre-Armv8 architectures.
 
-.. glossary::
-
-   A64
-      The 64-bit Arm instruction set used in AArch64 state.
-      All A64 instructions are 32 bits.
-
-   AArch64 state
-      The Arm 64-bit Execution state that uses 64-bit general purpose
-      registers, and a 64-bit program counter (PC), Stack Pointer (SP), and
-      exception link registers (ELR).
+   T32
+      The mixed 32- and 16-bit length instruction set, known as Thumb in
+      pre-Armv8 architectures.
 
    AArch64
-      Execution state provides a single instruction set, A64.
+      The Arm 64-bit Execution state, supported by the Armv8-A architecture.
+      In this state, addresses are held in 64-bit registers, and instructions in
+      the base instruction set can use 64-bit registers for their processing.
+      This state supports the A64 instruction set.
+
+   A64
+      The 32-bit length instruction set, supported by the Armv8-A architecture.
 
    EL0
-      The lowest Exception level on AArch64. The Exception level that is used to execute
-      user applications, in Non-secure state.
+      The lowest Exception level, used to execute user applications,
+      in Non-secure state.
 
    EL1
-      Privileged Exception level on AArch64. The Exception level that is used to execute
-      Operating Systems, in Non-secure state.
+      Privileged Exception level, used to execute Operating Systems,
+      in Non-secure state.
 
    EL2
-      Hypervisor Exception level on AArch64. The Exception level that is used to execute
-      hypervisor code. EL2 is always in Non-secure state.
+      Hypervisor Exception level, used to execute hypervisor code,
+      in Non-secure state.
 
    EL3
-      Secure Monitor Exception level on AArch64. The Exception level that is used to
-      execute Secure Monitor code, which handles the transitions between
-      Non-secure and Secure states.  EL3 is always in Secure state.
+      The highest Exception level, used to execute Secure Monitor code, which
+      handles the transitions between Non-secure and Secure states.
+      EL3 is always in Secure state.
 
 RISC-V
 ------

--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -243,7 +243,7 @@ legitimately be loaded into either EL1 or EL2 on AArch64 and HS/VS/S mode on RIS
 AArch64 Exception Levels
 ------------------------
 
-On AArch64 UEFI shall execute as 64-bit code at either EL1 or EL2, as defined in
+On AArch64 UEFI shall execute as A64 code at either EL1 or EL2, as defined in
 [UEFI]_ § 2.3.6, depending on whether or not virtualization is available at OS
 load time.
 

--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -509,9 +509,9 @@ If firmware doesn't support `ResetSystem()` during runtime services, then the ca
 will immediately return, and the OS should fall back to an architecture or
 platform specific reset mechanism.
 
-On AArch64 platforms implementing [PSCI]_,
-if `ResetSystem()` is not implemented then the Operating System should fall
-back to making a PSCI call to reset or shutdown the system.
+On platforms implementing [PSCI]_, if `ResetSystem()` is not implemented then
+the Operating System should fall back to making a PSCI call to reset or shutdown
+the system.
 
 Runtime Variable Access
 -----------------------

--- a/source/chapter3-secureworld.rst
+++ b/source/chapter3-secureworld.rst
@@ -4,20 +4,31 @@
 Privileged or Secure Firmware
 *****************************
 
-AArch32 Multiprocessor Startup Protocol
-=======================================
+Arm Multiprocessor Startup Protocol
+===================================
+
+AArch32 platforms
+-----------------
+
 There is no standard multiprocessor startup or CPU power management mechanism
-for ARMv7 and earlier platforms.
+for pre-Armv7 platforms.
 The OS is expected to use platform specific drivers for CPU power management.
 Firmware must advertize the CPU power management mechanism in the Devicetree
 system description or the ACPI tables so that the OS can enable the correct
 driver.
 At `ExitBootServices()` time, all secondary CPUs must be parked or powered off.
 
-AArch64 Multiprocessor Startup Protocol
-=======================================
-On AArch64 platforms, Firmware resident in EL3 must implement and
-conform to the Power State Coordination Interface specification [PSCI]_.
+Starting with Armv7, Firmware resident in Monitor mode may implement and conform
+to the Power State Coordination Interface specification [PSCI]_.
+
+Platforms without Monitor mode but with Hyp mode may implement PSCI in Hyp mode
+(leaving only Supervisor mode available to an operating system).
+
+AArch64 platforms
+-----------------
+
+On AArch64 platforms, Firmware resident in EL3 must implement and conform to the
+PSCI specification.
 
 Platforms without EL3 must implement one of:
 

--- a/source/chapter3-secureworld.rst
+++ b/source/chapter3-secureworld.rst
@@ -16,7 +16,7 @@ At `ExitBootServices()` time, all secondary CPUs must be parked or powered off.
 
 AArch64 Multiprocessor Startup Protocol
 =======================================
-On AArch64 platforms, Firmware resident in Trustzone EL3 must implement and
+On AArch64 platforms, Firmware resident in EL3 must implement and
 conform to the Power State Coordination Interface specification [PSCI]_.
 
 Platforms without EL3 must implement one of:

--- a/source/references.rst
+++ b/source/references.rst
@@ -18,6 +18,10 @@
    <https://docs.kernel.org/arch/arm64/booting.html>`_,
    Linux kernel
 
+.. [ArmARM] `Arm Architecture Reference Manual for A-profile architecture Issue J.a
+   <https://developer.arm.com/documentation/ddi0487/ja>`_,
+   April 2023, `Arm Limited <https://www.arm.com/>`_
+
 .. [PSCI] `Arm Power State Coordination Interface issue E (PSCI v1.2).
    <https://developer.arm.com/documentation/den0022/e>`_
    Mar 2023, `Arm Limited <https://www.arm.com/>`_


### PR DESCRIPTION
Here is a pull request to add support for the Armv8-R AArch64 architecture profile.

The first four commits should be fairly non-controversial, even if they modify EBBR a bit in term of suggestions and requirements, as they mostly pave the way.

The last commit adds v8-R64 support per-se.

Update: drop the v8-R64 addition completely and reduce a bit the ambitions; only the last commit has a slight requirement change around generalising PSCI reset.