### PR TITLE
Bump PSCI + recommend >= 1.0

### DIFF
--- a/source/chapter3-secureworld.rst
+++ b/source/chapter3-secureworld.rst
@@ -28,6 +28,14 @@ However, the spin table protocol is strongly discouraged.
 Future versions of this specification will only allow PSCI, and PSCI should
 be implemented in all new designs.
 
+It is recommended that firmware implementing PSCI supports version 1.0 or later.
+[#PSCINote]_
+
+.. [#PSCINote]
+   PSCI version 1.0 is considered as an errata fix release for version 0.2,
+   where functions interfaces have been stabilized.
+   It also introduced the `PSCI_FEATURES` function, for standardized discovery.
+
 RISC-V Multiprocessor Startup Protocol
 ======================================
 The resident firmware in M mode or hypervisor running in HS mode must implement

--- a/source/references.rst
+++ b/source/references.rst
@@ -18,9 +18,9 @@
    <https://docs.kernel.org/arch/arm64/booting.html>`_,
    Linux kernel
 
-.. [PSCI] `Arm Power State Coordination Interface issue E (PSCI v1.2).
-   <https://developer.arm.com/documentation/den0022/e>`_
-   Mar 2023, `Arm Limited <https://www.arm.com/>`_
+.. [PSCI] `Arm Power State Coordination Interface issue F (PSCI v1.3 ALPHA).
+   <https://developer.arm.com/documentation/den0022/f>`_
+   July 2023, `Arm Limited <https://www.arm.com/>`_
 
 .. [ArmBBR] `Arm Base Boot Requirements specification Issue G (v2.0)
    <https://developer.arm.com/documentation/den0044/g>`_


### PR DESCRIPTION
As a comparison, Arm SystemReady IR / BBR require PSCI 1.1.