### PR TITLE
Require authenticated FMP firmware updates

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -610,8 +610,9 @@ In-band firmware update
 
 If firmware update is performed in-band (firmware on the application processor
 updates itself), then the firmware shall implement the `UpdateCapsule()` runtime
-service and accept updates in the "Firmware Management Protocol Data Capsule
-Structure" format as described in :UEFI:`23.3`. [#FMPNote]_
+service and accept only authenticated updates in the "Firmware Management
+Protocol Data Capsule Structure" format as described in :UEFI:`23.3`, with
+`IMAGE_ATTRIBUTE_AUTHENTICATION_REQUIRED` set. [#FMPNote]_
 `UpdateCapsule()` is only required before `ExitBootServices()` is called.
 
 .. [#FMPNote] The `UpdateCapsule()` runtime service is expected to be suitable
@@ -621,6 +622,13 @@ Structure" format as described in :UEFI:`23.3`. [#FMPNote]_
    before `ExitBootServices()` is called.
 
    https://fwupd.org/
+
+Firmware is allowed to accept capsules not containing firmware updates in any
+format, with or without authentication. [#SignalingNote]_
+
+.. [#SignalingNote] Capsules not containing firmware updates can be used as a
+   signaling mean between OS and firmware, as described in [DEPBOOT]_ for
+   example.
 
 Firmware is also required to provide an EFI System Resource Table (ESRT) as
 described in :UEFI:`23.4`.

--- a/source/references.rst
+++ b/source/references.rst
@@ -17,6 +17,10 @@ Bibliography
    <https://uefi.org/sites/default/files/resources/ACPI_Spec_6_5_Aug29.pdf>`_,
    August 2022, `UEFI Forum <https://uefi.org/>`_
 
+.. [DEPBOOT] `Dependable Boot Specification version 0.1-alpha.
+   <https://gitlab.com/Linaro/trustedsubstrate/mbfw/uploads/3d0d7d11ca9874dc9115616b418aa330/mbfw.pdf>`_
+   November 2021, `Linaro Limited and contributors <https://www.linaro.org>`_
+
 .. [DTSCHEMA] `Devicetree schema tools v2024.02
    <https://github.com/devicetree-org/dt-schema/releases/tag/v2024.02>`_,
    `Devicetree.org <https://www.devicetree.org/>`_


### PR DESCRIPTION
Require to accept only authenticated in-band firmware updates and mention the corresponding attribute for FMP.

This is supported in U-Boot since a while now.
Also, we require it in SystemReady IR since v2.0.