### PR TITLE
Clarify that ConnectController must be implemented

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -124,8 +124,8 @@ interface specific UEFI protocols, and so they have been made optional.
        resource with the type 'HII'. HII resource images are not needed to run
        the UEFI shell or the SCT.
    * - `ConnectController()`
-     - The `ConnectController()` boot service is not required to support the
-       `EFI_PLATFORM_DRIVER_OVERRIDE_PROTOCOL`,
+     - The `ConnectController()` boot service must be implemented but it is not
+       required to support the `EFI_PLATFORM_DRIVER_OVERRIDE_PROTOCOL`,
        `EFI_DRIVER_FAMILY_OVERRIDE_PROTOCOL`, and
        `EFI_BUS_SPECIFIC_DRIVER_OVERRIDE_PROTOCOL`.
        These override protocols are


### PR DESCRIPTION
Make it clearer that even though ConnectController() is not required to support all protocols, it must be implemented.

See #114 and [the call of Jan 15](https://github.com/ARM-software/ebbr/wiki/EBBR-Notes-2024.01.15)

