### PR TITLE
Remove /chosen/efivarfile

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -361,9 +361,6 @@ take precedence. [#DTSchNote]_
    * - ``/chosen/stdout-path``
      - This Property is required. It is necessary for console output.
        ([DTSPEC]_ § 3.6)
-   * - ``/chosen/efivarfile``
-     - This Property is required when the EFI Variables are stored in a file as
-       detailed in section :ref:`section-efi-vars-file-format`.
 
 The DTB must be contained in memory of type `EfiACPIReclaimMemory`.
 [#ACPIMemNote]_

--- a/source/chapter5-variable-storage.rst
+++ b/source/chapter5-variable-storage.rst
@@ -13,17 +13,6 @@ to the EFI variable by updating the file.
 This chapter defines a file-format for EFI variables that both the firmware
 and the operating system can rely on.
 
-The path of the file will be related to the operating system via the Devicetree
-as UTF-8 string ``/chosen/efivarfile``.
-
-.. warning::
-   The Devicetree node name and contents are not final at this point and are
-   subject to change.
-
-   The string will likely contain a part identifying a filesystem uniquely,
-   followed by a comma and followed by a file path in the identified filesystem.
-   For example: "UUID=1234:45678,/ubootefi.var".
-
 All integer fields are stored in little-endian byte order.
 
 File header


### PR DESCRIPTION
We are still discussing how the location of the EFI variable file should be signaled to the OS.