### PR TITLE
Deprecate spin tables

### DIFF
--- a/source/chapter3-secureworld.rst
+++ b/source/chapter3-secureworld.rst
@@ -22,18 +22,11 @@ On AArch64 platforms, Firmware resident in Trustzone EL3 must implement and
 conform to the Power State Coordination Interface specification [PSCI]_ and to
 the SMC Calling Convention [SMCCC]_.
 
-Platforms without EL3 must implement one of:
+Platforms without EL3 must implement PSCI and SMCCC at EL2 (leaving only EL1
+available to an operating system).
 
-- PSCI and SMCCC at EL2 (leaving only EL1 available to an operating system)
-- Linux AArch64 spin tables [LINUXA64BOOT]_ (Devicetree only)
-
-.. warning:: The spin table protocol is strongly discouraged.
-   Future versions of this specification will only allow PSCI and SMCCC, and
-   they should be implemented in all new designs.
-
-It is recommended that firmware implementing PSCI supports version 1.0 or later
-[#PSCINote]_ and that firmware implementing SMCCC supports version 1.1 or later
-[#SMCCCNote]_.
+It is recommended that firmware implements PSCI version 1.0 or later
+[#PSCINote]_ and SMCCC version 1.1 or later [#SMCCCNote]_.
 
 .. [#PSCINote] PSCI version 1.0 is considered as an errata fix release for
    version 0.2, where functions interfaces have been stabilized.

--- a/source/references.rst
+++ b/source/references.rst
@@ -25,10 +25,6 @@ Bibliography
    <https://github.com/devicetree-org/devicetree-specification/releases/tag/v0.4>`_,
    `Devicetree.org <https://www.devicetree.org/>`_
 
-.. [LINUXA64BOOT] `Linux Documentation/arm64/booting.rst
-   <https://docs.kernel.org/arch/arm64/booting.html>`_,
-   Linux kernel
-
 .. [PSCI] `Arm Power State Coordination Interface issue F (PSCI v1.3 ALPHA).
    <https://developer.arm.com/documentation/den0022/f>`_
    July 2023, `Arm Limited <https://www.arm.com/>`_


### PR DESCRIPTION
Let's deprecate the spin tables for good and allow only PSCI for AArch64.
