### PR TITLE
Recommend psci node under firmware

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -383,6 +383,12 @@ take precedence. [#DTSchNote]_
      - This Property is required. It is necessary for console output.
        ([DTSPEC]_ § 3.6)
 
+When a ``/psci`` node is provided, it is recommended that it is located under
+the ``/firmware`` node. [#PSCINote]_
+
+.. [#PSCINote] Legacy systems also commonly located the ``/psci`` node under the
+   root node ``/``.
+
 The DTB must be contained in memory of type `EfiACPIReclaimMemory`.
 [#ACPIMemNote]_
 


### PR DESCRIPTION
Add a recommendation to locate the /psci node of the Devicetree under the /firmware node.
Add a note (to OSes' intention) that legacy systems did not do so, but rather located it under the root node /.

This was originally reported by Jon as a [limitation of Arm's certification tools](https://gitlab.arm.com/systemready/systemready-scripts/-/issues/33).

Do we all find it acceptable to add recommendations on Devicetree in EBBR?