### PR TITLE
Update UEFI version to 2.11

### DIFF
--- a/scripts/update_uefi_index.py
+++ b/scripts/update_uefi_index.py
@@ -9,7 +9,7 @@ import enum
 import logging
 import requests
 
-UEFI_INDEX_URL = 'https://uefi.org/specs/UEFI/2.10_A/index.html'
+UEFI_INDEX_URL = 'https://uefi.org/specs/UEFI/2.11/index.html'
 uefi_csv = os.path.dirname(__file__) + '/../source/extensions/uefi_index.csv'
 logger = logging.getLogger(__name__)
 

--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -10,7 +10,7 @@ platforms.
 UEFI Version
 ============
 
-This document uses version 2.10 Errata A of the UEFI specification [UEFI]_.
+This document uses version 2.11 of the UEFI specification [UEFI]_.
 
 UEFI Compliance
 ===============

--- a/source/extensions/uefi_index.csv
+++ b/source/extensions/uefi_index.csv
@@ -1,2049 +1,2051 @@
-1,Introduction,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html
-1.1,Principle of Inclusive Terminology,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#principle-of-inclusive-terminology
-1.2,UEFI Driver Model Extensions,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#uefi-driver-model-extensions
-1.3,Organization,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#organization
-1.4,Goals,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#goals
-1.5,Target Audience,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#target-audience
-1.6,UEFI Design Overview,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#uefi-design-overview
-1.7,UEFI Driver Model,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#uefi-driver-model
-1.7.1,UEFI Driver Model Goals,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#uefi-driver-model-goals
-1.7.2,Legacy Option ROM Issues,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#legacy-option-rom-issues
-1.8,Migration Requirements,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#migration-requirements
-1.8.1,Legacy Operating System Support,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#legacy-operating-system-support
-1.8.2,Supporting the UEFI Specification on a Legacy Platform,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#supporting-the-uefi-specification-on-a-legacy-platform
-1.9,Conventions Used in this Document,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#conventions-used-in-this-document
-1.9.1,Data Structure Descriptions,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#data-structure-descriptions
-1.9.2,Protocol Descriptions,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#protocol-descriptions
-1.9.3,Procedure Descriptions,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#procedure-descriptions
-1.9.4,Instruction Descriptions,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#instruction-descriptions
-1.9.5,Pseudo-Code Conventions,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#pseudo-code-conventions
-1.9.6,Typographic Conventions,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#typographic-conventions
-1.9.7,Number formats,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#number-formats
-1.9.7.1,Hexadecimal,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#hexadecimal
-1.9.7.2,Decimal,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#decimal
-1.9.8,SI & Binary prefixes,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#si-binary-prefixes
-1.9.9,Revision Numbers,https://uefi.org/specs/UEFI/2.10_A/01_Introduction.html#revision-numbers
-2,Overview,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html
-2.1,Boot Manager,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#boot-manager
-2.1.1,UEFI Images,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#uefi-images
-2.1.2,UEFI Applications,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#uefi-applications
-2.1.3,UEFI OS Loaders,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#uefi-os-loaders
-2.1.4,UEFI Drivers,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#uefi-drivers
-2.2,Firmware Core,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#firmware-core
-2.2.1,UEFI Services,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#uefi-services
-2.2.2,Runtime Services,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#runtime-services
-2.3,Calling Conventions,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#calling-conventions
-2.3.1,Data Types,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#data-types
-2.3.2,IA-32 Platforms,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#ia-32-platforms
-2.3.2.1,Handoff State,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#handoff-state
-2.3.2.2,Calling Convention,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#calling-convention
-2.3.3,Intel-Itanium--Based Platforms,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#intelitanium-based-platforms
-2.3.3.1,Handoff State,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#handoff-state-1
-2.3.3.2,Calling Convention,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#calling-convention-1
-2.3.4,x64 Platforms,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#x64-platforms
-2.3.4.1,Handoff State,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#handoff-state-2
-2.3.4.2,Detailed Calling Conventions,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#detailed-calling-conventions
-2.3.4.3,Enabling Paging or Alternate Translations in an Application,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#enabling-paging-or-alternate-translations-in-an-application
-2.3.5,AArch32 Platforms,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#aarch32-platforms
-2.3.5.1,Handoff State,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#handoff-state-3
-2.3.5.2,Enabling Paging or Alternate Translations in an Application,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#enabling-paging-or-alternate-translations-in-an-application-1
-2.3.5.3,Detailed Calling Convention,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#detailed-calling-convention
-2.3.6,AArch64 Platforms,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#aarch64-platforms
-2.3.6.1,Memory types,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#memory-types
-2.3.6.2,Handoff State,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#handoff-state-4
-2.3.6.3,Enabling Paging or Alternate Translations in an Application,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#enabling-paging-or-alternate-translations-in-an-application-2
-2.3.6.4,Detailed Calling Convention,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#detailed-calling-convention-1
-2.3.7,RISC-V Platforms,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#risc-v-platforms
-2.3.7.1,Handoff State,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#handoff-state-5
-2.3.7.2,Enabling Paging or Alternate Translations in an Application,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#enabling-paging-or-alternate-translations-in-an-application-3
-2.3.7.3,Detailed Calling Convention,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#detailed-calling-convention-2
-2.3.8,LoongArch Platforms,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#loongarch-platforms
-2.3.8.1,Handoff Statue,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#handoff-statue
-2.3.8.2,Detailed Calling Convention,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#id33
-2.4,Protocols,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#protocols
-2.5,UEFI Driver Model,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#uefi-driver-model
-2.5.1,Legacy Option ROM Issues,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#legacy-option-rom-issues
-2.5.1.1,32-bit/16-Bit Real Mode Binaries,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#bit-16-bit-real-mode-binaries
-2.5.1.2,Fixed Resources for Working with Option ROMs,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#fixed-resources-for-working-with-option-roms
-2.5.1.3,Matching Option ROMs to their Devices,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#matching-option-roms-to-their-devices
-2.5.1.4,Ties to PC-AT System Design,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#ties-to-pc-at-system-design
-2.5.1.5,Ambiguities in Specification and WorkaroundsBorn of Experience,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#ambiguities-in-specification-and-workaroundsborn-of-experience
-2.5.2,Driver Initialization,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#driver-initialization
-2.5.3,Host Bus Controllers,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#host-bus-controllers
-2.5.4,Device Drivers,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#device-drivers
-2.5.5,Bus Drivers,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#bus-drivers
-2.5.6,Platform Components,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#platform-components
-2.5.7,Hot-Plug Events,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#hot-plug-events
-2.5.8,EFI Services Binding,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#efi-services-binding
-2.6,Requirements,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#requirements
-2.6.1,Required Elements,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#required-elements
-2.6.2,Platform-Specific Elements,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#platform-specific-elements
-2.6.3,Driver-Specific Elements,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#driver-specific-elements
-2.6.4,Extensions to this Specification Published Elsewhere,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#extensions-to-this-specification-published-elsewhere
-2.6.5,Cryptographic Algorithm Requirement,https://uefi.org/specs/UEFI/2.10_A/02_Overview.html#cryptographic-algorithm-requirement
-3,Boot Manager,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html
-3.1,Firmware Boot Manager,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#firmware-boot-manager
-3.1.1,Boot Manager Programming,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#boot-manager-programming
-3.1.2,Load Option Processing,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#load-option-processing
-3.1.3,Load Options,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#load-options
-3.1.4,Boot Manager Capabilities,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#boot-manager-capabilities
-3.1.5,Launching Boot#### Applications,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#launching-boot-applications
-3.1.6,Launching Boot#### Load Options Using Hot Keys,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#launching-boot-load-options-using-hot-keys
-3.1.7,Required System Preparation Applications,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#required-system-preparation-applications
-3.2,Boot Manager Policy Protocol,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#boot-manager-policy-protocol
-3.2.1,EFI_BOOT_MANAGER_POLICY_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#efi-boot-manager-policy-protocol
-3.2.2,EFI_BOOT_MANAGER_POLICY_PROTOCOL.ConnectDevicePath(),https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#efi-boot-manager-policy-protocol-connectdevicepath
-3.2.3,EFI_BOOT_MANAGER_POLICY_PROTOCOL.ConnectDeviceClass(),https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#efi-boot-manager-policy-protocol-connectdeviceclass
-3.3,Globally Defined Variables,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#globally-defined-variables
-3.4,Boot Option Recovery,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#boot-option-recovery
-3.4.1,OS-Defined Boot Option Recovery,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#os-defined-boot-option-recovery
-3.4.2,Platform-Defined Boot Option Recovery,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#platform-defined-boot-option-recovery
-3.4.3,Boot Option Variables Default Boot Behavior,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#boot-option-variables-default-boot-behavior
-3.5,Boot Mechanisms,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#boot-mechanisms
-3.5.1,Boot via the Simple File Protocol,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#boot-via-the-simple-file-protocol
-3.5.1.1,Removable Media Boot Behavior,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#removable-media-boot-behavior
-3.5.2,Boot via the Load File Protocol,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#boot-via-the-load-file-protocol
-3.5.2.1,Network Booting,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#network-booting
-3.5.2.2,Future Boot Media,https://uefi.org/specs/UEFI/2.10_A/03_Boot_Manager.html#future-boot-media
-4,EFI System Table,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html
-4.1,UEFI Image Entry Point,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#uefi-image-entry-point
-4.1.1,EFI_IMAGE_ENTRY_POINT,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#efi-image-entry-point
-4.2,EFI Table Header,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#efi-table-header
-4.2.1,EFI_TABLE_HEADER,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#id4
-4.3,EFI System Table,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#efi-system-table-1
-4.3.1,EFI_SYSTEM_TABLE,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#id6
-4.4,EFI Boot Services Table,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#efi-boot-services-table
-4.4.1,EFI_BOOT_SERVICES,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#efi-boot-services
-4.5,EFI Runtime Services Table,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#efi-runtime-services-table
-4.5.1,EFI_RUNTIME_SERVICES,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#efi-runtime-services
-4.6,EFI Configuration Table & Properties Table,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#efi-configuration-table-properties-table
-4.6.1,EFI_CONFIGURATION_TABLE,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#efi-configuration-table
-4.6.1.1,Industry Standard Configuration Tables,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#industry-standard-configuration-tables
-4.6.1.2,JSON Configuration Tables,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#json-configuration-tables
-4.6.1.3,Devicetree Tables,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#devicetree-tables
-4.6.2,EFI_RT_PROPERTIES_TABLE,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#efi-rt-properties-table
-4.6.3,EFI_MEMORY_ATTRIBUTES_TABLE,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#efi-memory-attributes-table
-4.6.4,EFI_CONFORMANCE_PROFILE_TABLE,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#efi-conformance-profile-table
-4.6.5,Other Configuration Tables,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#other-configuration-tables
-4.7,Image Entry Point Examples,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#image-entry-point-examples
-4.7.1,Image Entry Point Examples,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#id18
-4.7.2,UEFI Driver Model Example,https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#uefi-driver-model-example
-4.7.3,UEFI Driver Model Example (Unloadable),https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#uefi-driver-model-example-unloadable
-4.7.4,EFI Driver Model Example (Multiple Instances),https://uefi.org/specs/UEFI/2.10_A/04_EFI_System_Table.html#efi-driver-model-example-multiple-instances
-5,GUID Partition Table (GPT) Disk Layout,https://uefi.org/specs/UEFI/2.10_A/05_GUID_Partition_Table_Format.html
-5.1,GPT and MBR disk layout comparison,https://uefi.org/specs/UEFI/2.10_A/05_GUID_Partition_Table_Format.html#gpt-and-mbr-disk-layout-comparison
-5.2,LBA 0 Format,https://uefi.org/specs/UEFI/2.10_A/05_GUID_Partition_Table_Format.html#lba-0-format
-5.2.1,Legacy Master Boot Record (MBR),https://uefi.org/specs/UEFI/2.10_A/05_GUID_Partition_Table_Format.html#legacy-master-boot-record-mbr
-5.2.2,OS Types,https://uefi.org/specs/UEFI/2.10_A/05_GUID_Partition_Table_Format.html#os-types
-5.2.3,Protective MBR,https://uefi.org/specs/UEFI/2.10_A/05_GUID_Partition_Table_Format.html#protective-mbr
-5.2.4,Partition Information,https://uefi.org/specs/UEFI/2.10_A/05_GUID_Partition_Table_Format.html#partition-information
-5.3,GUID Partition Table (GPT) Disk Layout,https://uefi.org/specs/UEFI/2.10_A/05_GUID_Partition_Table_Format.html#guid-partition-table-gpt-disk-layout-1
-5.3.1,GPT overview,https://uefi.org/specs/UEFI/2.10_A/05_GUID_Partition_Table_Format.html#gpt-overview
-5.3.2,GPT Header,https://uefi.org/specs/UEFI/2.10_A/05_GUID_Partition_Table_Format.html#gpt-header
-5.3.3,GPT Partition Entry Array,https://uefi.org/specs/UEFI/2.10_A/05_GUID_Partition_Table_Format.html#gpt-partition-entry-array
-6,Block Translation Table (BTT) Layout,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html
-6.1,Block Translation Table (BTT) Background,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#block-translation-table-btt-background
-6.2,Block Translation Table (BTT) Data Structures,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#block-translation-table-btt-data-structures
-6.2.1,BTT Info Block,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#btt-info-block
-6.2.2,BTT Map Entry,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#btt-map-entry
-6.2.3,BTT Flog,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#btt-flog
-6.2.4,BTT Data Area,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#btt-data-area
-6.2.5,NVDIMM Label Protocol Address Abstraction Guid,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#nvdimm-label-protocol-address-abstraction-guid
-6.3,BTT Theory of Operation,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#btt-theory-of-operation
-6.3.1,BTT Arenas,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#btt-arenas
-6.3.2,Atomicity of Data Blocks in an Arena,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#atomicity-of-data-blocks-in-an-arena
-6.3.3,Atomicity of BTT Data Structures,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#atomicity-of-btt-data-structures
-6.3.4,Writing the Initial BTT layout,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#writing-the-initial-btt-layout
-6.3.5,Validating BTT Arenas at start-up,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#validating-btt-arenas-at-start-up
-6.3.6,Validating the Flog entries at start-up,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#validating-the-flog-entries-at-start-up
-6.3.7,Read Path,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#read-path
-6.3.8,Write Path,https://uefi.org/specs/UEFI/2.10_A/06_Block_Transition_Table_Layout.html#write-path
-7,Services - Boot Services,https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html
-7.1,"Event, Timer, and Task Priority Services",https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#event-timer-and-task-priority-services
-7.1.1,EFI_BOOT_SERVICES.CreateEvent(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-createevent
-7.1.2,EFI_BOOT_SERVICES.CreateEventEx(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-createeventex
-7.1.3,EFI_BOOT_SERVICES.CloseEvent(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-closeevent
-7.1.4,EFI_BOOT_SERVICES.SignalEvent(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-signalevent
-7.1.5,EFI_BOOT_SERVICES.WaitForEvent(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-waitforevent
-7.1.6,EFI_BOOT_SERVICES.CheckEvent(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-checkevent
-7.1.7,EFI_BOOT_SERVICES.SetTimer(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-settimer
-7.1.8,EFI_BOOT_SERVICES.RaiseTPL(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-raisetpl
-7.1.9,EFI_BOOT_SERVICES.RestoreTPL(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-restoretpl
-7.2,Memory Allocation Services,https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#memory-allocation-services
-7.2.1,EFI_BOOT_SERVICES.AllocatePages(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-allocatepages
-7.2.2,EFI_BOOT_SERVICES.FreePages(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-freepages
-7.2.3,EFI_BOOT_SERVICES.GetMemoryMap(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-getmemorymap
-7.2.4,EFI_BOOT_SERVICES.AllocatePool(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-allocatepool
-7.2.5,EFI_BOOT_SERVICES.FreePool(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-freepool
-7.3,Protocol Handler Services,https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#protocol-handler-services
-7.3.1,Driver Model Boot Services,https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#driver-model-boot-services
-7.3.2,EFI_BOOT_SERVICES.InstallProtocolInterface(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-installprotocolinterface
-7.3.3,EFI_BOOT_SERVICES.UninstallProtocolInterface(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-uninstallprotocolinterface
-7.3.4,EFI_BOOT_SERVICES.ReinstallProtocolInterface(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-reinstallprotocolinterface
-7.3.5,EFI_BOOT_SERVICES.RegisterProtocolNotify(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-registerprotocolnotify
-7.3.6,EFI_BOOT_SERVICES.LocateHandle(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-locatehandle
-7.3.7,EFI_BOOT_SERVICES.HandleProtocol(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-handleprotocol
-7.3.8,EFI_BOOT_SERVICES.LocateDevicePath(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-locatedevicepath
-7.3.9,EFI_BOOT_SERVICES.OpenProtocol(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-openprotocol
-7.3.10,EFI_BOOT_SERVICES.CloseProtocol(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-closeprotocol
-7.3.11,EFI_BOOT_SERVICES.OpenProtocolInformation(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-openprotocolinformation
-7.3.12,EFI_BOOT_SERVICES.ConnectController(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-connectcontroller
-7.3.13,EFI_BOOT_SERVICES.DisconnectController(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-disconnectcontroller
-7.3.14,EFI_BOOT_SERVICES.ProtocolsPerHandle(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-protocolsperhandle
-7.3.15,EFI_BOOT_SERVICES.LocateHandleBuffer(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-locatehandlebuffer
-7.3.16,EFI_BOOT_SERVICES.LocateProtocol(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-locateprotocol
-7.3.17,EFI_BOOT_SERVICES.InstallMultipleProtocolInterfaces(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-installmultipleprotocolinterfaces
-7.3.18,EFI_BOOT_SERVICES.UninstallMultipleProtocolInterfaces(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-uninstallmultipleprotocolinterfaces
-7.4,Image Services,https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#image-services
-7.4.1,EFI_BOOT_SERVICES.LoadImage(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-loadimage
-7.4.2,EFI_BOOT_SERVICES.StartImage(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-startimage
-7.4.3,EFI_BOOT_SERVICES.UnloadImage(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-unloadimage
-7.4.4,EFI_IMAGE_ENTRY_POINT,https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-image-entry-point
-7.4.5,EFI_BOOT_SERVICES.Exit(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-exit
-7.4.6,EFI_BOOT_SERVICES.ExitBootServices(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-exitbootservices
-7.5,Miscellaneous Boot Services,https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#miscellaneous-boot-services
-7.5.1,EFI_BOOT_SERVICES.SetWatchdogTimer(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-setwatchdogtimer
-7.5.2,EFI_BOOT_SERVICES.Stall(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-stall
-7.5.3,EFI_BOOT_SERVICES.CopyMem(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-copymem
-7.5.4,EFI_BOOT_SERVICES.SetMem(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-setmem
-7.5.5,EFI_BOOT_SERVICES.GetNextMonotonicCount(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-getnextmonotoniccount
-7.5.6,EFI_BOOT_SERVICES.InstallConfigurationTable(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-installconfigurationtable
-7.5.7,EFI_BOOT_SERVICES.CalculateCrc32(),https://uefi.org/specs/UEFI/2.10_A/07_Services_Boot_Services.html#efi-boot-services-calculatecrc32
-8,Services - Runtime Services,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html
-8.1,Runtime Services Rules and Restrictions,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#runtime-services-rules-and-restrictions
-8.1.1,"Exception for Machine Check, INIT, and NMI",https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#exception-for-machine-check-init-and-nmi
-8.2,Variable Services,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#variable-services
-8.2.1,GetVariable(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#getvariable
-8.2.2,GetNextVariableName(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#getnextvariablename
-8.2.3,SetVariable(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#setvariable
-8.2.4,QueryVariableInfo(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#queryvariableinfo
-8.2.5,Using the EFI_VARIABLE_AUTHENTICATION_3 descriptor,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#using-the-efi-variable-authentication-3-descriptor
-8.2.6,Using the EFI_VARIABLE_AUTHENTICATION_2 descriptor,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#using-the-efi-variable-authentication-2-descriptor
-8.2.7,Hardware Error Record Persistence,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#hardware-error-record-persistence
-8.2.7.1,Hardware Error Record Non-Volatile Store,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#hardware-error-record-non-volatile-store
-8.2.7.2,Hardware Error Record Variables,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#hardware-error-record-variables
-8.2.7.3,Common Platform Error Record Format,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#common-platform-error-record-format
-8.3,Time Services,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#time-services
-8.3.1,GetTime(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#gettime
-8.3.2,SetTime(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#settime
-8.3.3,GetWakeupTime(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#getwakeuptime
-8.3.4,SetWakeupTime(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#setwakeuptime
-8.4,Virtual Memory Services,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#virtual-memory-services
-8.4.1,SetVirtualAddressMap(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#setvirtualaddressmap
-8.4.2,ConvertPointer(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#convertpointer
-8.5,Miscellaneous Runtime Services,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#miscellaneous-runtime-services
-8.5.1,Reset System,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#reset-system
-8.5.1.1,ResetSystem(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#resetsystem
-8.5.2,Get Next High Monotonic Count,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#get-next-high-monotonic-count
-8.5.2.1,GetNextHighMonotonicCount(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#getnexthighmonotoniccount
-8.5.3,Update Capsule,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#update-capsule
-8.5.3.1,UpdateCapsule(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#updatecapsule
-8.5.3.2,Capsule Definition,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#capsule-definition
-8.5.3.3,EFI_MEMORY_RANGE_CAPSULE_GUID,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#efi-memory-range-capsule-guid
-8.5.3.4,QueryCapsuleCapabilities(),https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#querycapsulecapabilities
-8.5.4,Exchanging information between the OS and Firmware,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#exchanging-information-between-the-os-and-firmware
-8.5.5,Delivery of Capsules via file on Mass Storage Device,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#delivery-of-capsules-via-file-on-mass-storage-device
-8.5.6,UEFI variable reporting on the Success or any Errors encountered in processing of capsules after restart,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#uefi-variable-reporting-on-the-success-or-any-errors-encountered-in-processing-of-capsules-after-restart
-8.5.6.1,EFI_CAPSULE_REPORT_GUID,https://uefi.org/specs/UEFI/2.10_A/08_Services_Runtime_Services.html#efi-capsule-report-guid
-9,Protocols - EFI Loaded Image,https://uefi.org/specs/UEFI/2.10_A/09_Protocols_EFI_Loaded_Image.html
-9.1,EFI Loaded Image Protocol,https://uefi.org/specs/UEFI/2.10_A/09_Protocols_EFI_Loaded_Image.html#efi-loaded-image-protocol
-9.1.1,EFI_LOADED_IMAGE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/09_Protocols_EFI_Loaded_Image.html#id3
-9.1.2,EFI_LOADED_IMAGE_PROTOCOL.Unload(),https://uefi.org/specs/UEFI/2.10_A/09_Protocols_EFI_Loaded_Image.html#efi-loaded-image-protocol-unload
-9.2,EFI Loaded Image Device Path Protocol,https://uefi.org/specs/UEFI/2.10_A/09_Protocols_EFI_Loaded_Image.html#efi-loaded-image-device-path-protocol
-9.2.1,EFI_LOADED_IMAGE_DEVICE_PATH_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/09_Protocols_EFI_Loaded_Image.html#id6
-10,Protocols - Device Path Protocol,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html
-10.1,Device Path Overview,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#device-path-overview
-10.2,EFI Device Path Protocol,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-protocol
-10.3,Device Path Nodes,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#device-path-nodes
-10.3.1,Generic Device Path Structures,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#generic-device-path-structures
-10.3.2,Hardware Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#hardware-device-path
-10.3.2.1,PCI Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#pci-device-path
-10.3.2.2,PCCARD Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#pccard-device-path
-10.3.2.3,Memory Mapped Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#memory-mapped-device-path
-10.3.2.4,Vendor Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#vendor-device-path
-10.3.2.5,Controller Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#controller-device-path
-10.3.2.6,BMC Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#bmc-device-path
-10.3.3,ACPI Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#acpi-device-path
-10.3.3.1,ACPI _ADR Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#acpi-adr-device-path
-10.3.3.2,NVDIMM Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#nvdimm-device-path
-10.3.4,Messaging Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#messaging-device-path
-10.3.4.1,ATAPI Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#atapi-device-path
-10.3.4.2,SCSI Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#scsi-device-path
-10.3.4.3,Fibre Channel Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#fibre-channel-device-path
-10.3.4.4,1394 Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#device-path
-10.3.4.5,USB Device Paths,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#usb-device-paths
-10.3.4.6,SATA Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#sata-device-path
-10.3.4.7,USB Device Paths (WWID),https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#usb-device-paths-wwid
-10.3.4.8,Device Logical Unit,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#device-logical-unit
-10.3.4.9,I 2 O Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#i-2-o-device-path
-10.3.4.10,MAC Address Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#mac-address-device-path
-10.3.4.11,IPv4 Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#ipv4-device-path
-10.3.4.12,IPv6 Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#ipv6-device-path
-10.3.4.13,2. VLAN device path node,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#vlan-device-path-node
-10.3.4.14,InfiniBand Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#infiniband-device-path
-10.3.4.15,UART Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#uart-device-path
-10.3.4.16,Vendor-Defined Messaging Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#vendor-defined-messaging-device-path
-10.3.4.17,UART Flow Control Messaging Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#uart-flow-control-messaging-path
-10.3.4.18,Serial Attached SCSI (SAS) Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#serial-attached-scsi-sas-device-path
-10.3.4.19,Serial Attached SCSI (SAS) Extended Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#serial-attached-scsi-sas-extended-device-path
-10.3.4.20,iSCSI Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#iscsi-device-path
-10.3.4.21,NVM Express namespace messaging device path node,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#nvm-express-namespace-messaging-device-path-node
-10.3.4.22,Uniform Resource Identifiers (URI) Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#uniform-resource-identifiers-uri-device-path
-10.3.4.23,UFS (Universal Flash Storage) device messaging devicepath node,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#ufs-universal-flash-storage-device-messaging-devicepath-node
-10.3.4.24,SD (Secure Digital) Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#sd-secure-digital-device-path
-10.3.4.25,EFI Bluetooth Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-bluetooth-device-path
-10.3.4.26,Wireless Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#wireless-device-path
-10.3.4.27,eMMC (Embedded Multi-Media Card) Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#emmc-embedded-multi-media-card-device-path
-10.3.4.28,EFI BluetoothLE Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-bluetoothle-device-path
-10.3.4.29,DNS Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#dns-device-path
-10.3.4.30,NVDIMM Namespace path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#nvdimm-namespace-path
-10.3.4.31,REST Service Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#rest-service-device-path
-10.3.4.32,NVMe over Fabric (NVMe-oF) Namespace Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#nvme-over-fabric-nvme-of-namespace-device-path
-10.3.4.33,NVMe over Fabric (NVMe-oF) Namespace Device Path Example,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#nvme-over-fabric-nvme-of-namespace-device-path-example
-10.3.5,Media Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#media-device-path
-10.3.5.1,Hard Drive,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#hard-drive
-10.3.5.2,CD-ROM Media Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#cd-rom-media-device-path
-10.3.5.3,Vendor-Defined Media Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#vendor-defined-media-device-path
-10.3.5.4,File Path Media Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#file-path-media-device-path
-10.3.5.5,Media Protocol Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#media-protocol-device-path
-10.3.5.6,PIWG Firmware File,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#piwg-firmware-file
-10.3.5.7,PIWG Firmware Volume,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#piwg-firmware-volume
-10.3.5.8,Relative Offset Range,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#relative-offset-range
-10.3.5.9,RAM Disk,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#ram-disk
-10.3.6,BIOS Boot Specification Device Path,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#bios-boot-specification-device-path
-10.4,Device Path Generation Rules,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#device-path-generation-rules
-10.4.1,Housekeeping Rules,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#housekeeping-rules
-10.4.2,Rules with ACPI _HID and _UID,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#rules-with-acpi-hid-and-uid
-10.4.3,Rules with ACPI _ADR,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#rules-with-acpi-adr
-10.4.4,Hardware vs. Messaging Device Path Rules,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#hardware-vs-messaging-device-path-rules
-10.4.5,Media Device Path Rules,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#media-device-path-rules
-10.4.6,Other Rules,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#other-rules
-10.5,Device Path Utilities Protocol,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#device-path-utilities-protocol
-10.5.1,EFI_DEVICE_PATH_UTILITIES_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol
-10.5.2,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.GetDevicePathSize(),https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-getdevicepathsize
-10.5.3,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.DuplicateDevicePath(),https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-duplicatedevicepath
-10.5.4,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.AppendDevicePath(),https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-appenddevicepath
-10.5.5,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.AppendDeviceNode(),https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-appenddevicenode
-10.5.6,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.AppendDevicePathInstance(),https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-appenddevicepathinstance
-10.5.7,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.GetNextDevicePathInstance(),https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-getnextdevicepathinstance
-10.5.8,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.CreateDeviceNode(),https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-createdevicenode
-10.5.9,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.IsDevicePathMultiInstance(),https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-isdevicepathmultiinstance
-10.6,EFI Device Path Display Format Overview,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-display-format-overview
-10.6.1,Design Discussion,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#design-discussion
-10.6.1.1,Standardized Display Format,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#standardized-display-format
-10.6.1.2,Readability,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#readability
-10.6.1.3,Round-Trip Conversion,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#round-trip-conversion
-10.6.1.4,Command-Line Parsing,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#command-line-parsing
-10.6.1.5,Text Representation Basics,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#text-representation-basics
-10.6.1.6,Text Device Node Reference,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#text-device-node-reference
-10.6.2,Device Path to Text Protocol,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#device-path-to-text-protocol
-10.6.2.1,EFI_DEVICE_PATH_TO_TEXT_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-to-text-protocol
-10.6.3,EFI_DEVICE_PATH_TO_TEXT_PROTOCOL.ConvertDeviceNodeToText(),https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-to-text-protocol-convertdevicenodetotext
-10.6.4,EFI_DEVICE_PATH_TO_TEXT_PROTOCOL.ConvertDevicePathToText(),https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-to-text-protocol-convertdevicepathtotext
-10.6.5,Device Path from Text Protocol,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#device-path-from-text-protocol
-10.6.5.1,EFI_DEVICE_PATH_FROM_TEXT_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-from-text-protocol
-10.6.5.2,EFI_DEVICE_PATH_FROM_TEXT_PROTOCOL.ConvertTextToDeviceNode(),https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-from-text-protocol-converttexttodevicenode
-10.6.5.3,EFI_DEVICE_PATH_FROM_TEXT_PROTOCOL.ConvertTextToDevicePath(,https://uefi.org/specs/UEFI/2.10_A/10_Protocols_Device_Path_Protocol.html#efi-device-path-from-text-protocol-converttexttodevicepath
-11,Protocols - UEFI Driver Model,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html
-11.1,EFI Driver Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-binding-protocol
-11.1.1,EFI_DRIVER_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#id1
-11.1.2,EFI_DRIVER_BINDING_PROTOCOL.Supported(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-binding-protocol-supported
-11.1.3,EFI_DRIVER_BINDING_PROTOCOL.Start(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-binding-protocol-start
-11.1.4,EFI_DRIVER_BINDING_PROTOCOL.Stop(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-binding-protocol-stop
-11.2,EFI Platform Driver Override Protocol,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-platform-driver-override-protocol
-11.2.1,EFI_PLATFORM_DRIVER_OVERRIDE_PROTOCOL.GetDriver(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-platform-driver-override-protocol-getdriver
-11.2.2,EFI_PLATFORM_DRIVER_OVERRIDE_PROTOCOL.GetDriverPath(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-platform-driver-override-protocol-getdriverpath
-11.2.3,EFI_PLATFORM_DRIVER_OVERRIDE_PROTOCOL.DriverLoaded(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-platform-driver-override-protocol-driverloaded
-11.3,EFI Bus Specific Driver Override Protocol,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-bus-specific-driver-override-protocol
-11.3.1,EFI_BUS_SPECIFIC_DRIVER_OVERRIDE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-bus-specific-driver-override-protocol-protocols-uefi-driver-model
-11.3.2,EFI_BUS_SPECIFIC_DRIVER_OVERRIDE_PROTOCOL.GetDriver(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-bus-specific-driver-override-protocol-getdriver
-11.4,EFI Driver Diagnostics Protocol,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-diagnostics-protocol
-11.4.1,EFI_DRIVER_DIAGNOSTICS2_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-diagnostics2-protocol
-11.4.2,EFI_DRIVER_DIAGNOSTICS2_PROTOCOL.RunDiagnostics(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-diagnostics2-protocol-rundiagnostics
-11.5,EFI Component Name Protocol,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-component-name-protocol
-11.5.1,EFI_COMPONENT_NAME2_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-component-name2-protocol
-11.5.2,EFI_COMPONENT_NAME2_PROTOCOL.GetDriverName(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-component-name2-protocol-getdrivername
-11.5.3,EFI_COMPONENT_NAME2_PROTOCOL.GetControllerName(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-component-name2-protocol-getcontrollername
-11.6,EFI Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-service-binding-protocol
-11.6.1,EFI_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-service-binding-protocol-1-protocols-uefi-driver-model
-11.6.2,EFI_SERVICE_BINDING_PROTOCOL.CreateChild(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-service-binding-protocol-createchild
-11.6.3,EFI_SERVICE_BINDING_PROTOCOL.DestroyChild(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-service-binding-protocol-destroychild
-11.7,EFI Platform to Driver Configuration Protocol,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-platform-to-driver-configuration-protocol
-11.7.1,EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#id5
-11.7.2,EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL.Query(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-platform-to-driver-configuration-protocol-query
-11.7.3,EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL.Response(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-platform-to-driver-configuration-protocol-response
-11.7.4,DMTF SM CLP ParameterTypeGuid,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#dmtf-sm-clp-parametertypeguid
-11.8,EFI Driver Supported EFI Version Protocol,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-supported-efi-version-protocol
-11.8.1,EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#id6
-11.9,EFI Driver Family Override Protocol,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-family-override-protocol
-11.9.1,Overview,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#overview
-11.9.1.1,EFI_DRIVER_FAMILY_OVERRIDE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-family-override-protocol-protocols-uefi-driver-model
-11.9.1.2,EFI_DRIVER_FAMILY_OVERRIDE_PROTOCOL.GetVersion(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-family-override-protocol-getversion
-11.10,EFI Driver Health Protocol,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-health-protocol
-11.10.1,EFI_DRIVER_HEALTH_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#id9
-11.10.2,EFI_DRIVER_HEALTH_PROTOCOL.GetHealthStatus(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-health-protocol-gethealthstatus
-11.10.3,EFI_DRIVER_HEALTH_PROTOCOL.Repair(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-driver-health-protocol-repair
-11.10.4,UEFI Boot Manager Algorithms,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#uefi-boot-manager-algorithms
-11.10.4.1,All Controllers Healthy,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#all-controllers-healthy
-11.10.4.2,Process a Controller Until Terminal StateReached,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#process-a-controller-until-terminal-statereached
-11.10.4.3,Repair Notification Function,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#repair-notification-function
-11.10.4.4,Process Message List,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#process-message-list
-11.10.4.5,Process HII Form,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#process-hii-form
-11.10.5,UEFI Driver Algorithms,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#uefi-driver-algorithms
-11.10.5.1,Driver Entry Point Updates,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#driver-entry-point-updates
-11.10.5.2,Add global variable,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#add-global-variable
-11.10.5.3,Update private context structure,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#update-private-context-structure
-11.10.5.4,Implement GetHealthStatus() service,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#implement-gethealthstatus-service
-11.10.5.5,Implement Repair() service,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#implement-repair-service
-11.11,EFI Adapter Information Protocol,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-adapter-information-protocol
-11.11.1,EFI_ADAPTER_INFORMATION_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-adapter-information-protocol-protocols-uefi-driver-model
-11.11.2,EFI_ADAPTER_INFORMATION_PROTOCOL.EFI_ADAPTER_GET_INFO(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-adapter-information-protocol-efi-adapter-get-info
-11.11.3,EFI_ADAPTER_INFORMATION_PROTOCOL.EFI_ADAPTER_INFO_SET_INFO(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-adapter-information-protocol-efi-adapter-info-set-info
-11.11.4,EFI_ADAPTER_INFORMATION_PROTOCOL. EFI_ADAPTER_INFO_GET_SUPPORTED_TYPES(),https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-adapter-information-protocol-efi-adapter-info-get-supported-types
-11.12,EFI Adapter Information Protocol Information Types,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#efi-adapter-information-protocol-information-types
-11.12.1,Network Media State,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#network-media-state
-11.12.2,Network Boot,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#network-boot
-11.12.3,SAN MAC Address,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#san-mac-address
-11.12.4,IPV6 Support from UNDI,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#ipv6-support-from-undi
-11.12.5,Network Media Type,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#network-media-type
-11.12.6,Coherent Device Attribute Table (CDAT) Type,https://uefi.org/specs/UEFI/2.10_A/11_Protocols_UEFI_Driver_Model.html#coherent-device-attribute-table-cdat-type
-12,Protocols - Console Support,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html
-12.1,Console I/O Protocol,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#console-i-o-protocol
-12.1.1,Overview,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#overview
-12.1.2,ConsoleIn Definition,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#consolein-definition
-12.2,Simple Text Input Ex Protocol,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#simple-text-input-ex-protocol
-12.2.1,EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-input-ex-protocol
-12.2.2,EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-input-ex-protocol-reset
-12.2.3,EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.ReadKeyStrokeEx(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-input-ex-protocol-readkeystrokeex
-12.2.4,EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.SetState(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-input-ex-protocol-setstate
-12.2.5,EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.RegisterKeyNotify(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-input-ex-protocol-registerkeynotify
-12.2.6,EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.UnregisterKeyNotify(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-input-ex-protocol-unregisterkeynotify
-12.3,Simple Text Input Protocol,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#simple-text-input-protocol
-12.3.1,EFI_SIMPLE_TEXT_INPUT_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-input-protocol
-12.3.2,EFI_SIMPLE_TEXT_INPUT_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-input-protocol-reset
-12.3.3,EFI_SIMPLE_TEXT_INPUT_PROTOCOL.ReadKeyStroke(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-input-protocol-readkeystroke
-12.3.4,ConsoleOut or StandardError,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#consoleout-or-standarderror
-12.4,Simple Text Output Protocol,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#simple-text-output-protocol
-12.4.1,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-output-protocol
-12.4.2,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-reset
-12.4.3,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.OutputString(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-outputstring
-12.4.4,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.TestString(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-teststring
-12.4.5,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.QueryMode(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-querymode
-12.4.6,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.SetMode(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-setmode
-12.4.7,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.SetAttribute(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-setattribute
-12.4.8,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.ClearScreen(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-clearscreen
-12.4.9,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.SetCursorPosition(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-setcursorposition
-12.4.10,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.EnableCursor(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-enablecursor
-12.5,Simple Pointer Protocol,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#simple-pointer-protocol
-12.5.1,EFI_SIMPLE_POINTER_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-pointer-protocol
-12.5.2,EFI_SIMPLE_POINTER_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-pointer-protocol-reset
-12.5.3,EFI_SIMPLE_POINTER_PROTOCOL.GetState(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-pointer-protocol-getstate
-12.6,EFI Simple Pointer Device Paths,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-simple-pointer-device-paths
-12.7,Absolute Pointer Protocol,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#absolute-pointer-protocol
-12.7.1,EFI_ABSOLUTE_POINTER_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-absolute-pointer-protocol
-12.7.2,EFI_ABSOLUTE_POINTER_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-absolute-pointer-protocol-reset
-12.7.3,EFI_ABSOLUTE_POINTER_PROTOCOL.GetState(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-absolute-pointer-protocol-getstate
-12.8,Serial I/O Protocol,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#serial-i-o-protocol
-12.8.1,EFI_SERIAL_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-serial-io-protocol
-12.8.2,Serial Device Identification,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#serial-device-identification
-12.8.3,Serial Device Type GUIDs,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#serial-device-type-guids
-12.8.3.1,EFI_SERIAL_IO_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-serial-io-protocol-reset
-12.8.3.2,EFI_SERIAL_IO_PROTOCOL.SetAttributes(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-serial-io-protocol-setattributes
-12.8.3.3,EFI_SERIAL_IO_PROTOCOL.SetControl(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-serial-io-protocol-setcontrol
-12.8.3.4,EFI_SERIAL_IO_PROTOCOL.GetControl(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-serial-io-protocol-getcontrol
-12.8.3.5,EFI_SERIAL_IO_PROTOCOL.Write(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-serial-io-protocol-write
-12.8.3.6,EFI_SERIAL_IO_PROTOCOL.Read(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-serial-io-protocol-read
-12.9,Graphics Output Protocol,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#graphics-output-protocol
-12.9.1,Blt Buffer,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#blt-buffer
-12.9.2,EFI_GRAPHICS_OUTPUT_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-graphics-output-protocol
-12.9.2.1,EFI_GRAPHICS_OUTPUT_PROTOCOL.QueryMode(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-graphics-output-protocol-querymode
-12.9.2.2,EFI_GRAPHICS_OUTPUT_PROTOCOL.SetMode(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-graphics-output-protocol-setmode
-12.9.2.3,EFI_GRAPHICS_OUTPUT_PROTOCOL.Blt(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-graphics-output-protocol-blt
-12.9.2.4,EFI_EDID_DISCOVERED_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-edid-discovered-protocol
-12.9.2.5,EFI_EDID_ACTIVE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-edid-active-protocol
-12.9.2.6,EFI_EDID_OVERRIDE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-edid-override-protocol
-12.9.2.7,EFI_EDID_OVERRIDE_PROTOCOL.GetEdid(),https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#efi-edid-override-protocol-getedid
-12.10,Rules for PCI/AGP Devices,https://uefi.org/specs/UEFI/2.10_A/12_Protocols_Console_Support.html#rules-for-pci-agp-devices
-13,Protocols - Media Access,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html
-13.1,Load File Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#load-file-protocol
-13.1.1,EFI_LOAD_FILE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-load-file-protocol
-13.1.2,EFI_LOAD_FILE_PROTOCOL.LoadFile(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-load-file-protocol-loadfile
-13.2,Load File 2 Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#load-file-2-protocol
-13.2.1,EFI_LOAD_FILE2_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-load-file2-protocol
-13.2.2,EFI_LOAD_FILE2_PROTOCOL.LoadFile(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-load-file2-protocol-loadfile
-13.3,File System Format,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#file-system-format
-13.3.1,System Partition,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#system-partition
-13.3.1.1,File System Format,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#file-system-format-1
-13.3.1.2,File Names,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#file-names
-13.3.1.3,Directory Structure,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#directory-structure
-13.3.2,Partition Discovery,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#partition-discovery
-13.3.2.1,ISO-9660 and El Torito,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#iso-9660-and-el-torito
-13.3.3,Number and Location of System Partitions,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#number-and-location-of-system-partitions
-13.3.4,Media Formats,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#media-formats
-13.3.4.1,Removable Media,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#removable-media
-13.3.4.2,Diskette,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#diskette
-13.3.4.3,Hard Drive,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#hard-drive
-13.3.4.4,CD-ROM and DVD-ROM,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#cd-rom-and-dvd-rom
-13.3.4.5,Network,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#network
-13.4,Simple File System Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#simple-file-system-protocol
-13.4.1,EFI_SIMPLE_FILE_SYSTEM_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-simple-file-system-protocol
-13.4.2,EFI_SIMPLE_FILE SYSTEM_PROTOCOL.OpenVolume(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-simple-file-system-protocol-openvolume
-13.5,File Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#file-protocol
-13.5.1,EFI_FILE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol
-13.5.2,EFI_FILE_PROTOCOL.Open(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-open
-13.5.3,EFI_FILE_PROTOCOL.Close(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-close
-13.5.4,EFI_FILE_PROTOCOL.Delete(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-delete
-13.5.5,EFI_FILE_PROTOCOL.Read(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-read
-13.5.6,EFI_FILE_PROTOCOL.Write(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-write
-13.5.7,EFI_FILE_PROTOCOL.OpenEx(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-openex
-13.5.8,EFI_FILE_PROTOCOL.ReadEx(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-readex
-13.5.9,EFI_FILE_PROTOCOL.WriteEx(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-writeex
-13.5.10,EFI_FILE_PROTOCOL.FlushEx(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-flushex
-13.5.11,EFI_FILE_PROTOCOL.SetPosition(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-setposition
-13.5.12,EFI_FILE_PROTOCOL.GetPosition(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-getposition
-13.5.13,EFI_FILE_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-getinfo
-13.5.14,EFI_FILE_PROTOCOL.SetInfo(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-setinfo
-13.5.15,EFI_FILE_PROTOCOL.Flush(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-protocol-flush
-13.5.16,EFI_FILE_INFO,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-info
-13.5.17,EFI_FILE_SYSTEM_INFO,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-system-info
-13.5.18,EFI_FILE_SYSTEM_VOLUME_LABEL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-file-system-volume-label
-13.6,Tape Boot Support,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#tape-boot-support
-13.6.1,Tape I/O Support,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#tape-i-o-support
-13.6.2,Tape I/O Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#tape-i-o-protocol
-13.6.2.1,EFI_TAPE_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-tape-io-protocol
-13.6.2.2,EFI_TAPE_IO_PROTOCOL.TapeRead(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-tape-io-protocol-taperead
-13.6.2.3,EFI_TAPE_IO_PROTOCOL.TapeWrite(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-tape-io-protocol-tapewrite
-13.6.2.4,EFI_TAPE_IO_PROTOCOL.TapeRewind(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-tape-io-protocol-taperewind
-13.6.2.5,EFI_TAPE_IO_PROTOCOL.TapeSpace(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-tape-io-protocol-tapespace
-13.6.2.6,EFI_TAPE_IO_PROTOCOL.TapeWriteFM(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-tape-io-protocol-tapewritefm
-13.6.2.7,EFI_TAPE_IO_PROTOCOL.TapeReset(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-tape-io-protocol-tapereset
-13.6.3,Tape Header Format,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#tape-header-format
-13.7,Disk I/O Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#disk-i-o-protocol
-13.7.1,EFI_DISK_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-disk-io-protocol
-13.7.2,EFI_DISK_IO_PROTOCOL.ReadDisk(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-disk-io-protocol-readdisk
-13.7.3,EFI_DISK_IO_PROTOCOL.WriteDisk(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-disk-io-protocol-writedisk
-13.8,Disk I/O 2 Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#disk-i-o-2-protocol
-13.8.1,EFI_DISK_IO2_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-disk-io2-protocol
-13.8.2,EFI_DISK_IO2_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-disk-io2-protocol-cancel
-13.8.3,EFI_DISK_IO2_PROTOCOL.ReadDiskEx(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-disk-io2-protocol-readdiskex
-13.8.4,EFI_DISK_IO2_PROTOCOL.WriteDiskEx(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-disk-io2-protocol-writediskex
-13.8.5,EFI_DISK_IO2_PROTOCOL.FlushDiskEx(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-disk-io2-protocol-flushdiskex
-13.9,Block I/O Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#block-i-o-protocol
-13.9.1,EFI_BLOCK_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io-protocol
-13.9.2,EFI_BLOCK_IO_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io-protocol-reset
-13.9.3,EFI_BLOCK_IO_PROTOCOL.ReadBlocks(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io-protocol-readblocks
-13.9.4,EFI_BLOCK_IO_PROTOCOL.WriteBlocks(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io-protocol-writeblocks
-13.9.5,EFI_BLOCK_IO_PROTOCOL.FlushBlocks(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io-protocol-flushblocks
-13.10,Block I/O 2 Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#block-i-o-2-protocol
-13.10.1,EFI_BLOCK_IO2_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io2-protocol
-13.10.2,EFI_BLOCK_IO2_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io2-protocol-reset
-13.10.3,EFI_BLOCK_IO2_PROTOCOL.ReadBlocksEx(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io2-protocol-readblocksex
-13.10.4,EFI_BLOCK_IO2_PROTOCOL.WriteBlocksEx(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io2-protocol-writeblocksex
-13.10.5,EFI_BLOCK_IO2_PROTOCOL.FlushBlocksEx(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io2-protocol-flushblocksex
-13.11,Inline Cryptographic Interface Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#inline-cryptographic-interface-protocol
-13.11.1,EFI_BLOCK_IO_CRYPTO_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol
-13.11.2,EFI_BLOCK_IO_CRYPTO_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-reset
-13.11.3,EFI_BLOCK_IO_CRYPTO_PROTOCOL.GetCapabilities(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-getcapabilities
-13.11.4,EFI_BLOCK_IO_CRYPTO_PROTOCOL.SetConfiguration(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-setconfiguration
-13.11.5,EFI_BLOCK_IO_CRYPTO_PROTOCOL.GetConfiguration(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-getconfiguration
-13.11.6,EFI_BLOCK_IO_CRYPTO_PROTOCOL.ReadExtended(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-readextended
-13.11.7,EFI_BLOCK_IO_CRYPTO_PROTOCOL.WriteExtended(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-writeextended
-13.11.8,EFI_BLOCK_IO_CRYPTO_PROTOCOL.FlushBlocks(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-flushblocks
-13.12,Erase Block Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#erase-block-protocol
-13.12.1,EFI_ERASE_BLOCK_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-erase-block-protocol
-13.12.2,EFI_ERASE_BLOCK_PROTOCOL.EraseBlocks(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-erase-block-protocol-eraseblocks
-13.13,ATA Pass Thru Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#ata-pass-thru-protocol
-13.13.1,EFI_ATA_PASS_THRU_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol
-13.13.2,EFI_ATA_PASS_THRU_PROTOCOL.PassThru(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-passthru
-13.13.3,EFI_ATA_PASS_THRU_PROTOCOL.GetNextPort(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-getnextport
-13.13.4,EFI_ATA_PASS_THRU_PROTOCOL.GetNextDevice(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-getnextdevice
-13.13.5,EFI_ATA_PASS_THRU_PROTOCOL.BuildDevicePath(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-builddevicepath
-13.13.6,EFI_ATA_PASS_THRU_PROTOCOL.GetDevice(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-getdevice
-13.13.7,EFI_ATA_PASS_THRU_PROTOCOL.ResetPort(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-resetport
-13.13.8,EFI_ATA_PASS_THRU_PROTOCOL.ResetDevice(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-resetdevice
-13.14,Storage Security Command Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#storage-security-command-protocol
-13.14.1,EFI_STORAGE_SECURITY_COMMAND_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-storage-security-command-protocol
-13.14.2,EFI_STORAGE_SECURITY_COMMAND_PROTOCOL.ReceiveData(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-storage-security-command-protocol-receivedata
-13.14.3,EFI_STORAGE_SECURITY_COMMAND_PROTOCOL.SendData(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-storage-security-command-protocol-senddata
-13.15,NVM Express Pass Through Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#nvm-express-pass-through-protocol
-13.15.1,EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-nvm-express-pass-thru-protocol
-13.15.2,EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL.PassThru(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-nvm-express-pass-thru-protocol-passthru
-13.15.3,EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL.GetNextNamespace(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-nvm-express-pass-thru-protocol-getnextnamespace
-13.15.4,EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL.BuildDevicePath(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-nvm-express-pass-thru-protocol-builddevicepath
-13.15.5,EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL.GetNamespace(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-nvm-express-pass-thru-protocol-getnamespace
-13.16,SD MMC Pass Thru Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#sd-mmc-pass-thru-protocol
-13.16.1,EFI_SD_MMC_PASS_THRU_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-sd-mmc-pass-thru-protocol
-13.16.2,EFI_SD_MMC_PASS_THRU_PROTOCOL.PassThru(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-sd-mmc-pass-thru-protocol-passthru
-13.16.3,EFI_SD_MMC_PASS_THRU_PROTOCOL.GetNextSlot(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-sd-mmc-pass-thru-protocol-getnextslot
-13.16.4,EFI_SD_MMC_PASS_THRU_PROTOCOL.BuildDevicePath(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-sd-mmc-pass-thru-protocol-builddevicepath
-13.16.5,EFI_SD_MMC_PASS_THRU_PROTOCOL.GetSlotNumber(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-sd-mmc-pass-thru-protocol-getslotnumber
-13.16.6,EFI_SD_MMC_PASS_THRU_PROTOCOL.ResetDevice(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-sd-mmc-pass-thru-protocol-resetdevice
-13.17,RAM Disk Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#ram-disk-protocol
-13.17.1,EFI_RAM_DISK_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ram-disk-protocol
-13.17.2,EFI_RAM_DISK_PROTOCOL.Register(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ram-disk-protocol-register
-13.17.3,EFI_RAM_DISK_PROTOCOL.Unregister(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ram-disk-protocol-unregister
-13.18,Partition Information Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#partition-information-protocol
-13.19,NVDIMM Label Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#nvdimm-label-protocol
-13.19.1,EFI_NVDIMM_LABEL_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-nvdimm-label-protocol
-13.19.2,EFI_NVDIMM_LABEL_PROTOCOL.LabelStorageInformation(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-nvdimm-label-protocol-labelstorageinformation
-13.19.3,EFI_NVDIMM_LABEL_PROTOCOL.LabelStorageRead(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-nvdimm-label-protocol-labelstorageread
-13.19.4,EFI_NVDIMM_LABEL_PROTOCOL.LabelStorageWrite(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-nvdimm-label-protocol-labelstoragewrite
-13.19.5,Label Storage Area Description,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#label-storage-area-description
-13.19.5.1,Updating the Name of a Namespace Description,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#updating-the-name-of-a-namespace-description
-13.20,EFI UFS Device Config Protocol,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ufs-device-config-protocol
-13.20.1,EFI_UFS_DEVICE_CONFIG_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#id117
-13.20.2,EFI_UFS_DEVICE_CONFIG_PROTOCOL.RwUfsDescriptor(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ufs-device-config-protocol-rwufsdescriptor
-13.20.3,EFI_UFS_DEVICE_CONFIG_PROTOCOL.RwUfsFlag(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ufs-device-config-protocol-rwufsflag
-13.20.4,EFI_UFS_DEVICE_CONFIG_PROTOCOL.RwUfsAttribute(),https://uefi.org/specs/UEFI/2.10_A/13_Protocols_Media_Access.html#efi-ufs-device-config-protocol-rwufsattribute
-14,Protocols - PCI Bus Support,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html
-14.1,PCI Root Bridge I/O Support,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-root-bridge-i-o-support
-14.1.1,PCI Root Bridge I/O Overview,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-root-bridge-i-o-overview
-14.1.2,Sample PCI Architectures,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#sample-pci-architectures
-14.2,PCI Root Bridge I/O Protocol,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-root-bridge-i-o-protocol
-14.2.1,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol
-14.2.2,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.PollMem(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-pollmem
-14.2.3,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.PollIo(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-pollio
-14.2.4,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Mem.Read(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-mem-read
-14.2.5,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Mem.Write(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-mem-write
-14.2.6,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Io.Read(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-io-read
-14.2.7,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Io.Write(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-io-write
-14.2.8,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Pci.Read(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-pci-read
-14.2.9,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Pci.Write(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-pci-write
-14.2.10,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.CopyMem(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-copymem
-14.2.11,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Map(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-map
-14.2.12,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Unmap(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-unmap
-14.2.13,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.AllocateBuffer(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-allocatebuffer
-14.2.14,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.FreeBuffer(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-freebuffer
-14.2.15,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Flush(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-flush
-14.2.16,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.GetAttributes(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-getattributes
-14.2.17,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.SetAttributes(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-setattributes
-14.2.18,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Configuration(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-configuration
-14.2.19,PCI Root Bridge Device Paths,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-root-bridge-device-paths
-14.3,PCI Driver Model,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-driver-model
-14.3.1,PCI Driver Initialization,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-driver-initialization
-14.3.2,Driver Diagnostics Protocol,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#driver-diagnostics-protocol
-14.3.3,Component Name Protocol,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#component-name-protocol
-14.3.4,Driver Family Override Protocol,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#driver-family-override-protocol
-14.3.5,PCI Bus Drivers,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-bus-drivers
-14.3.6,Driver Binding Protocol for PCI Bus Drivers,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#driver-binding-protocol-for-pci-bus-drivers
-14.3.7,PCI Enumeration,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-enumeration
-14.3.8,PCI Device Drivers,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-device-drivers
-14.3.9,Driver Binding Protocol for PCI Device Drivers,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#driver-binding-protocol-for-pci-device-drivers
-14.4,EFI PCI I/O Protocol,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-i-o-protocol
-14.4.1,EFI_PCI_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#id32
-14.4.2,EFI_PCI_IO_PROTOCOL.PollMem(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-pollmem
-14.4.3,EFI_PCI_IO_PROTOCOL.PollIo(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-pollio
-14.4.4,EFI_PCI_IO_PROTOCOL.Mem.Read(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-mem-read
-14.4.5,EFI_PCI_IO_PROTOCOL.Mem.Write(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-mem-write
-14.4.6,EFI_PCI_IO_PROTOCOL.Io.Read(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-io-read
-14.4.7,EFI_PCI_IO_PROTOCOL.Io.Write(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-io-write
-14.4.8,EFI_PCI_IO_PROTOCOL.Pci.Read(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-pci-read
-14.4.9,EFI_PCI_IO_PROTOCOL.Pci.Write(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-pci-write
-14.4.10,EFI_PCI_IO_PROTOCOL.CopyMem(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-copymem
-14.4.11,EFI_PCI_IO_PROTOCOL.Map(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-map
-14.4.12,EFI-PCI-IO-PROTOCOL-Unmap(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-unmap
-14.4.13,EFI_PCI_IO_PROTOCOL.AllocateBuffer(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-allocatebuffer
-14.4.14,EFI_PCI_IO_PROTOCOL.FreeBuffer(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-freebuffer
-14.4.15,EFI_PCI_IO_PROTOCOL.Flush(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-flush
-14.4.16,EFI_PCI_IO_PROTOCOL.GetLocation(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-getlocation
-14.4.17,EFI_PCI_IO_PROTOCOL.Attributes(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-attributes
-14.4.18,EFI_PCI_IO_PROTOCOL.GetBarAttributes(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-getbarattributes
-14.4.19,EFI_PCI_IO_PROTOCOL.SetBarAttributes(),https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-setbarattributes
-14.4.20,PCI Device Paths,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-device-paths
-14.4.21,PCI Option ROMs,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-option-roms
-14.4.22,PCI Bus Driver Responsibilities,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-bus-driver-responsibilities
-14.4.23,PCI Device Driver Responsibilities,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-device-driver-responsibilities
-14.4.24,Nonvolatile Storage,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#nonvolatile-storage
-14.4.25,PCI Hot-Plug Events,https://uefi.org/specs/UEFI/2.10_A/14_Protocols_PCI_Bus_Support.html#pci-hot-plug-events
-15,Protocols - SCSI Driver Models and Bus Support,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html
-15.1,SCSI Driver Model Overview,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-driver-model-overview
-15.2,SCSI Bus Drivers,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-bus-drivers
-15.2.1,Driver Binding Protocol for SCSI Bus Drivers,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#driver-binding-protocol-for-scsi-bus-drivers
-15.2.2,SCSI Enumeration,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-enumeration
-15.3,SCSI Device Drivers,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-device-drivers
-15.3.1,Driver Binding Protocol for SCSI Device Drivers,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#driver-binding-protocol-for-scsi-device-drivers
-15.4,EFI SCSI I/O Protocol,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-scsi-i-o-protocol
-15.4.1,EFI_SCSI_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#id8
-15.4.2,EFI_SCSI_IO_PROTOCOL.GetDeviceType(),https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-scsi-io-protocol-getdevicetype
-15.4.3,EFI_SCSI_IO_PROTOCOL.GetDeviceLocation(),https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-scsi-io-protocol-getdevicelocation
-15.4.4,EFI_SCSI_IO_PROTOCOL.ResetBus(),https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-scsi-io-protocol-resetbus
-15.4.5,EFI_SCSI_IO_PROTOCOL.ResetDevice(),https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-scsi-io-protocol-resetdevice
-15.4.6,EFI_SCSI_IO_PROTOCOL.ExecuteScsiCommand(),https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-scsi-io-protocol-executescsicommand
-15.5,SCSI Device Paths,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-device-paths
-15.5.1,SCSI Device Path Example,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-device-path-example
-15.5.2,ATAPI Device Path Example,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#atapi-device-path-example
-15.5.3,Fibre Channel Device Path Example,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#fibre-channel-device-path-example
-15.5.4,InfiniBand Device Path Example,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#infiniband-device-path-example
-15.6,SCSI Pass Thru Device Paths,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-pass-thru-device-paths
-15.7,Extended SCSI Pass Thru Protocol,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#extended-scsi-pass-thru-protocol
-15.7.1,EFI_EXT_SCSI_PASS_THRU_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol
-15.7.2,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.PassThru(),https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-passthru
-15.7.3,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.GetNextTargetLun(),https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-getnexttargetlun
-15.7.4,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.BuildDevicePath(),https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-builddevicepath
-15.7.5,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.GetTargetLun(),https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-gettargetlun
-15.7.6,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.ResetChannel(),https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-resetchannel
-15.7.7,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.ResetTargetLun(),https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-resettargetlun
-15.7.8,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.GetNextTarget(),https://uefi.org/specs/UEFI/2.10_A/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-getnexttarget
-16,Protocols - iSCSI Boot,https://uefi.org/specs/UEFI/2.10_A/16_Protocols_iSCSI_Boot.html
-16.1,Overview,https://uefi.org/specs/UEFI/2.10_A/16_Protocols_iSCSI_Boot.html#overview
-16.1.1,iSCSI UEFI Driver Layering,https://uefi.org/specs/UEFI/2.10_A/16_Protocols_iSCSI_Boot.html#iscsi-uefi-driver-layering
-16.2,EFI iSCSI Initiator Name Protocol,https://uefi.org/specs/UEFI/2.10_A/16_Protocols_iSCSI_Boot.html#efi-iscsi-initiator-name-protocol
-16.2.1,EFI_ISCSI_INITIATOR_NAME_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/16_Protocols_iSCSI_Boot.html#id4
-16.2.2,EFI_ISCSI_INITIATOR_NAME_PROTOCOL. Get(),https://uefi.org/specs/UEFI/2.10_A/16_Protocols_iSCSI_Boot.html#efi-iscsi-initiator-name-protocol-get
-16.2.3,EFI_ISCSI_INITIATOR_NAME_PROTOCOL.Set(),https://uefi.org/specs/UEFI/2.10_A/16_Protocols_iSCSI_Boot.html#efi-iscsi-initiator-name-protocol-set
-17,Protocols - USB Support,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html
-17.1,USB2 Host Controller Protocol,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#usb2-host-controller-protocol
-17.1.1,USB Host Controller Protocol Overview,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#usb-host-controller-protocol-overview
-17.1.2,EFI_USB2_HC_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol
-17.1.3,EFI_USB2_HC_PROTOCOL.GetCapability(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-getcapability
-17.1.4,EFI_USB2_HC_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-reset
-17.1.5,EFI_USB2_HC_PROTOCOL.GetState(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-getstate
-17.1.6,EFI_USB2_HC_PROTOCOL.SetState(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-setstate
-17.1.7,EFI_USB2_HC_PROTOCOL.ControlTransfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-controltransfer
-17.1.8,EFI_USB2_HC_PROTOCOL.BulkTransfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-bulktransfer
-17.1.9,EFI_USB2_HC_PROTOCOL.AsyncInterruptTransfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-asyncinterrupttransfer
-17.1.10,EFI_USB2_HC_PROTOCOL.SyncInterruptTransfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-syncinterrupttransfer
-17.1.11,EFI_USB2_HC_PROTOCOL.IsochronousTransfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-isochronoustransfer
-17.1.12,EFI_USB2_HC_PROTOCOL.AsyncIsochronousTransfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-asyncisochronoustransfer
-17.1.13,EFI_USB2_HC_PROTOCOL.GetRootHubPortStatus(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-getroothubportstatus
-17.1.14,EFI_USB2_HC_PROTOCOL.SetRootHubPortFeature(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-setroothubportfeature
-17.1.15,EFI_USB2_HC_PROTOCOL.ClearRootHubPortFeature(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-clearroothubportfeature
-17.2,USB Driver Model,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#usb-driver-model
-17.2.1,Scope,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#scope
-17.2.2,USB Bus Driver,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#usb-bus-driver
-17.2.2.1,USB Bus Driver Entry Point,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#usb-bus-driver-entry-point
-17.2.2.2,Driver Binding Protocol for USB Bus Drivers,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#driver-binding-protocol-for-usb-bus-drivers
-17.2.2.3,USB Hot-Plug Event,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#usb-hot-plug-event
-17.2.2.4,USB Bus Enumeration,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#usb-bus-enumeration
-17.2.3,USB Device Driver,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#usb-device-driver
-17.2.3.1,USB Device Driver Entry Point,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#usb-device-driver-entry-point
-17.2.3.2,Driver Binding Protocol for USB DeviceDrivers,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#driver-binding-protocol-for-usb-devicedrivers
-17.2.4,USB I/O Protocol,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#usb-i-o-protocol
-17.2.5,EFI_USB_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol
-17.2.6,EFI_USB_IO_PROTOCOL.UsbControlTransfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbcontroltransfer
-17.2.7,EFI_USB_IO_PROTOCOL.UsbBulkTransfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbbulktransfer
-17.2.8,EFI_USB_IO_PROTOCOL.UsbAsyncInterruptTransfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbasyncinterrupttransfer
-17.2.9,EFI_USB_IO_PROTOCOL.UsbSyncInterruptTransfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbsyncinterrupttransfer
-17.2.10,EFI_USB_IO_PROTOCOL.UsbIsochronousTransfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbisochronoustransfer
-17.2.11,EFI_USB_IO_PROTOCOL.UsbAsyncIsochronousTransfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbasyncisochronoustransfer
-17.2.12,EFI_USB_IO_PROTOCOL.UsbGetDeviceDescriptor(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbgetdevicedescriptor
-17.2.13,EFI_USB_IO_PROTOCOL.UsbGetConfigDescriptor(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbgetconfigdescriptor
-17.2.14,EFI_USB_IO_PROTOCOL.UsbGetInterfaceDescriptor(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbgetinterfacedescriptor
-17.2.15,EFI_USB_IO_PROTOCOL.UsbGetEndpointDescriptor(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbgetendpointdescriptor
-17.2.16,EFI_USB_IO_PROTOCOL.UsbGetStringDescriptor(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbgetstringdescriptor
-17.2.17,EFI_USB_IO_PROTOCOL.UsbGetSupportedLanguages(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbgetsupportedlanguages
-17.2.18,EFI_USB_IO_PROTOCOL.UsbPortReset(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbportreset
-17.3,USB Function Protocol,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#usb-function-protocol
-17.3.1,EFI_USBFN_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol
-17.3.2,EFI_USBFN_IO_PROTOCOL.DetectPort(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-detectport
-17.3.3,EFI_USBFN_IO_PROTOCOL.ConfigureEnableEndpoints(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-configureenableendpoints
-17.3.4,EFI_USBFN_IO_PROTOCOL.GetEndpointMaxPacketSize(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-getendpointmaxpacketsize
-17.3.5,EFI_USBFN_IO_PROTOCOL.GetDeviceInfo(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-getdeviceinfo
-17.3.6,EFI_USBFN_IO_PROTOCOL.GetVendorIdProductId(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-getvendoridproductid
-17.3.7,EFI_USBFN_IO_PROTOCOL.AbortTransfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-aborttransfer
-17.3.8,EFI_USBFN_IO_PROTOCOL.GetEndpointStallState(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-getendpointstallstate
-17.3.9,EFI_USBFN_IO_PROTOCOL.SetEndpointStallState(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-setendpointstallstate
-17.3.10,EFI_USBFN_IO_PROTOCOL.EventHandler(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-eventhandler
-17.3.11,EFI_USBFN_IO_PROTOCOL.Transfer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-transfer
-17.3.12,EFI_USBFN_IO_PROTOCOL.GetMaxTransferSize(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-getmaxtransfersize
-17.3.13,EFI_USBFN_IO_PROTOCOL.AllocateTransferBuffer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-allocatetransferbuffer
-17.3.14,EFI_USBFN_IO_PROTOCOL.FreeTransferBuffer(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-freetransferbuffer
-17.3.15,EFI_USBFN_IO_PROTOCOL.StartController(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-startcontroller
-17.3.16,EFI_USBFN_IO_PROTOCOL.StopController(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-stopcontroller
-17.3.16.1,Description,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#description
-17.3.17,EFI_USBFN_IO_PROTOCOL.SetEndpointPolicy(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-setendpointpolicy
-17.3.18,EFI_USBFN_IO_PROTOCOL.GetEndpointPolicy(),https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-getendpointpolicy
-17.3.19,USB Function Sequence Diagram,https://uefi.org/specs/UEFI/2.10_A/17_Protocols_USB_Support.html#usb-function-sequence-diagram
-18,Protocols - Debugger Support,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html
-18.1,Overview,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#overview
-18.2,EFI Debug Support Protocol,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debug-support-protocol
-18.2.1,EFI Debug Support Protocol Overview,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debug-support-protocol-overview
-18.2.2,EFI_DEBUG_SUPPORT_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#id5
-18.2.3,EFI_DEBUG_SUPPORT_PROTOCOL.GetMaximumProcessorIndex(),https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debug-support-protocol-getmaximumprocessorindex
-18.2.4,EFI_DEBUG_SUPPORT_PROTOCOL.RegisterPeriodicCallback(),https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debug-support-protocol-registerperiodiccallback
-18.2.5,EFI_DEBUG_SUPPORT_PROTOCOL.RegisterExceptionCallback(),https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debug-support-protocol-registerexceptioncallback
-18.2.6,EFI_DEBUG_SUPPORT_PROTOCOL.InvalidateInstructionCache(),https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debug-support-protocol-invalidateinstructioncache
-18.3,EFI Debugport Protocol,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debugport-protocol
-18.3.1,EFI Debugport Overview,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debugport-overview
-18.3.2,EFI_DEBUGPORT_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#id13
-18.3.3,EFI_DEBUGPORT_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debugport-protocol-reset
-18.3.4,EFI_DEBUGPORT_PROTOCOL.Write(),https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debugport-protocol-write
-18.3.5,EFI_DEBUGPORT_PROTOCOL.Read(),https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debugport-protocol-read
-18.3.6,EFI_DEBUGPORT_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debugport-protocol-poll
-18.3.7,Debugport Device Path,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#debugport-device-path
-18.3.8,EFI Debugport Variable,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debugport-variable
-18.4,EFI Debug Support Table,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-debug-support-table
-18.4.1,Overview,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#overview-1
-18.4.2,EFI System Table Location,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-system-table-location
-18.4.3,EFI Image Info,https://uefi.org/specs/UEFI/2.10_A/18_Protocols_Debugger_Support.html#efi-image-info
-19,Protocols - Compression Algorithm Specification,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html
-19.1,Algorithm Overview,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#algorithm-overview
-19.2,Data Format,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#data-format
-19.2.1,Bit Order,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#bit-order
-19.2.2,Overall Structure,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#overall-structure
-19.2.3,Block Structure,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#block-structure
-19.2.3.1,Block Header,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#block-header
-19.2.3.2,Block Body,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#block-body
-19.3,Compressor Design,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#compressor-design
-19.3.1,Overall Process,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#overall-process
-19.3.2,String Info Log,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#string-info-log
-19.3.2.1,Data Structures,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#data-structures
-19.3.2.2,Searching the Tree,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#searching-the-tree
-19.3.2.3,Adding String Info,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#adding-string-info
-19.3.2.4,Deleting String Info,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#deleting-string-info
-19.3.3,Huffman Code Generation,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#huffman-code-generation
-19.3.3.1,Huffman Tree Generation,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#huffman-tree-generation
-19.3.3.2,Code Length Adjustment,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#code-length-adjustment
-19.3.3.3,Code Generation,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#code-generation
-19.4,Decompressor Design,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#decompressor-design
-19.5,Decompress Protocol,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#decompress-protocol
-19.5.1,EFI_DECOMPRESS_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#efi-decompress-protocol
-19.5.2,EFI_DECOMPRESS_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#efi-decompress-protocol-getinfo
-19.5.3,EFI_DECOMPRESS_PROTOCOL.Decompress(),https://uefi.org/specs/UEFI/2.10_A/19_Protocols_Compression_Algorithm_Specification.html#efi-decompress-protocol-decompress
-20,Protocols - ACPI Protocols,https://uefi.org/specs/UEFI/2.10_A/20_Protocols_ACPI_Protocols.html
-20.1,EFI_ACPI_TABLE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/20_Protocols_ACPI_Protocols.html#efi-acpi-table-protocol
-20.2,EFI_ACPI_TABLE_PROTOCOL.InstallAcpiTable(),https://uefi.org/specs/UEFI/2.10_A/20_Protocols_ACPI_Protocols.html#efi-acpi-table-protocol-installacpitable
-20.3,EFI_ACPI_TABLE_PROTOCOL.UninstallAcpiTable(),https://uefi.org/specs/UEFI/2.10_A/20_Protocols_ACPI_Protocols.html#efi-acpi-table-protocol-uninstallacpitable
-21,Protocols - String Services,https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html
-21.1,Unicode Collation Protocol,https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html#unicode-collation-protocol
-21.1.1,EFI_UNICODE_COLLATION_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html#efi-unicode-collation-protocol
-21.1.2,EFI_UNICODE_COLLATION_PROTOCOL.StriColl(),https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html#efi-unicode-collation-protocol-stricoll
-21.1.3,EFI_UNICODE_COLLATION_PROTOCOL.MetaiMatch(),https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html#efi-unicode-collation-protocol-metaimatch
-21.1.4,EFI_UNICODE_COLLATION_PROTOCOL.StrLwr(),https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html#efi-unicode-collation-protocol-strlwr
-21.1.5,EFI_UNICODE_COLLATION_PROTOCOL.StrUpr(),https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html#efi-unicode-collation-protocol-strupr
-21.1.6,EFI_UNICODE_COLLATION_PROTOCOL.FatToStr(),https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html#efi-unicode-collation-protocol-fattostr
-21.1.7,EFI_UNICODE_COLLATION_PROTOCOL.StrToFat(),https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html#efi-unicode-collation-protocol-strtofat
-21.2,Regular Expression Protocol,https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html#regular-expression-protocol
-21.2.1,EFI_REGULAR_EXPRESSION_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html#efi-regular-expression-protocol
-21.2.2,EFI_REGULAR_EXPRESSION_PROTOCOL.MatchString(),https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html#efi-regular-expression-protocol-matchstring
-21.2.3,EFI_REGULAR_EXPRESSION_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html#efi-regular-expression-protocol-getinfo
-21.2.4,EFI Regular Expression Syntax Type Definitions,https://uefi.org/specs/UEFI/2.10_A/21_Protocols_String_Services.html#efi-regular-expression-syntax-type-definitions
-22,EFI Byte Code Virtual Machine,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html
-22.1,Overview,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#overview
-22.1.1,Processor Architecture Independence,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#processor-architecture-independence
-22.1.2,OS Independent,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#os-independent
-22.1.3,EFI Compliant,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#efi-compliant
-22.1.4,Coexistence of Legacy Option ROMs,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#coexistence-of-legacy-option-roms
-22.1.5,Relocatable Image,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#relocatable-image
-22.1.6,Size Restrictions Based on Memory Available,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#size-restrictions-based-on-memory-available
-22.2,Memory Ordering,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#memory-ordering
-22.3,Virtual Machine Registers,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#virtual-machine-registers
-22.4,Natural Indexing,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#natural-indexing
-22.4.1,Sign Bit,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#sign-bit
-22.4.2,Bits Assigned to Natural Units,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#bits-assigned-to-natural-units
-22.4.3,Constant,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#constant
-22.4.4,Natural Units,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#natural-units
-22.5,EBC Instruction Operands,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ebc-instruction-operands
-22.5.1,Direct Operands,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#direct-operands
-22.5.2,Indirect Operands,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#indirect-operands
-22.5.3,Indirect with Index Operands,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#indirect-with-index-operands
-22.5.4,Immediate Operands,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#immediate-operands
-22.6,EBC Instruction Syntax,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ebc-instruction-syntax
-22.7,Instruction Encoding,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#instruction-encoding
-22.7.1,Instruction Opcode Byte Encoding,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#instruction-opcode-byte-encoding
-22.7.2,Instruction Operands Byte Encoding,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#instruction-operands-byte-encoding
-22.7.3,Index/Immediate Data Encoding,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#index-immediate-data-encoding
-22.8,EBC Instruction Set,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ebc-instruction-set
-22.8.1,ADD,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#add
-22.8.2,AND,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#and
-22.8.3,ASHR,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ashr
-22.8.4,BREAK,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#break
-22.8.5,CALL,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#call
-22.8.6,CMP,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#cmp
-22.8.7,CMPI,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#cmpi
-22.8.8,DIV,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#div
-22.8.9,DIVU,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#divu
-22.8.10,EXTNDB,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#extndb
-22.8.11,EXTNDD,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#extndd
-22.8.12,EXTNDW,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#extndw
-22.8.13,JMP,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#jmp
-22.8.14,JMP8,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#jmp8
-22.8.15,LOADSP,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#loadsp
-22.8.16,MOD,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#mod
-22.8.17,MODU,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#modu
-22.8.18,MOV,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#mov
-22.8.19,MOVI,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#movi
-22.8.20,MOVIn,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#movin
-22.8.21,MOVn,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#movn
-22.8.22,MOVREL,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#movrel
-22.8.23,MOVsn,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#movsn
-22.8.24,MUL,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#mul
-22.8.25,MULU,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#mulu
-22.8.26,NEG,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#neg
-22.8.27,NOT,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#not
-22.8.28,OR,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#or
-22.8.29,POP,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#pop
-22.8.30,POPn,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#popn
-22.8.31,PUSH,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#push
-22.8.32,PUSHn,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#pushn
-22.8.33,RET,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ret
-22.8.34,SHL,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#shl
-22.8.35,SHR,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#shr
-22.8.36,STORESP,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#storesp
-22.8.37,SUB,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#sub
-22.8.38,XOR,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#xor
-22.9,Runtime and Software Conventions,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#runtime-and-software-conventions
-22.9.1,Calling Outside VM,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#calling-outside-vm
-22.9.2,Calling Inside VM,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#calling-inside-vm
-22.9.3,Parameter Passing,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#parameter-passing
-22.9.4,Return Values,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#return-values
-22.9.5,Binary Format,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#binary-format
-22.10,Architectural Requirements,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#architectural-requirements
-22.10.1,EBC Image Requirements,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ebc-image-requirements
-22.10.2,EBC Execution Interfacing Requirements,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ebc-execution-interfacing-requirements
-22.10.3,Interfacing Function Parameters Requirements,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#interfacing-function-parameters-requirements
-22.10.4,Function Return Requirements,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#function-return-requirements
-22.10.5,Function Return Values Requirements,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#function-return-values-requirements
-22.11,EBC Interpreter Protocol,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ebc-interpreter-protocol
-22.11.1,EFI_EBC_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#efi-ebc-protocol
-22.11.2,EFI_EBC_PROTOCOL.CreateThunk(),https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#efi-ebc-protocol-createthunk
-22.11.3,EFI_EBC_PROTOCOL.UnloadImage(),https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#efi-ebc-protocol-unloadimage
-22.11.4,EFI_EBC_PROTOCOL.RegisterICacheFlush(),https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#efi-ebc-protocol-registericacheflush
-22.11.5,EFI_EBC_PROTOCOL.GetVersion(),https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#efi-ebc-protocol-getversion
-22.12,EBC Tools,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ebc-tools
-22.12.1,EBC C Compiler,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ebc-c-compiler
-22.12.2,C Coding Convention,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#c-coding-convention
-22.12.3,EBC Interface Assembly Instructions,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ebc-interface-assembly-instructions
-22.12.4,Stack Maintenance and Argument Passing,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#stack-maintenance-and-argument-passing
-22.12.5,Native to EBC Arguments Calling Convention,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#native-to-ebc-arguments-calling-convention
-22.12.6,EBC to Native Arguments Calling Convention,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ebc-to-native-arguments-calling-convention
-22.12.7,EBC to EBC Arguments Calling Convention,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ebc-to-ebc-arguments-calling-convention
-22.12.8,Function Returns,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#function-returns
-22.12.9,Function Return Values,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#function-return-values
-22.12.10,Thunking,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#thunking
-22.12.10.1,Thunking EBC to Native Code,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#thunking-ebc-to-native-code
-22.12.10.2,Thunking Native Code to EBC,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#thunking-native-code-to-ebc
-22.12.10.3,Thunking EBC to EBC,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#thunking-ebc-to-ebc
-22.12.11,EBC Linker,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#ebc-linker
-22.12.12,Image Loader,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#image-loader
-22.12.13,Debug Support,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#debug-support
-22.13,VM Exception Handling,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#vm-exception-handling
-22.13.1,Divide By 0 Exception,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#divide-by-0-exception
-22.13.2,Debug Break Exception,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#debug-break-exception
-22.13.3,Invalid Opcode Exception,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#invalid-opcode-exception
-22.13.4,Stack Fault Exception,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#stack-fault-exception
-22.13.5,Alignment Exception,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#alignment-exception
-22.13.6,Instruction Encoding Exception,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#instruction-encoding-exception
-22.13.7,Bad Break Exception,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#bad-break-exception
-22.13.8,Undefined Exception,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#undefined-exception
-22.14,Option ROM Formats,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#option-rom-formats
-22.14.1,EFI Drivers for PCI Add-in Cards,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#efi-drivers-for-pci-add-in-cards
-22.14.2,Non-PCI Bus Support,https://uefi.org/specs/UEFI/2.10_A/22_EFI_Byte_Code_Virtual_Machine.html#non-pci-bus-support
-23,Firmware Update and Reporting,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html
-23.1,Firmware Management Protocol,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#firmware-management-protocol
-23.1.1,EFI_FIRMWARE_MANAGEMENT_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol
-23.1.2,EFI_FIRMWARE_MANAGEMENT_PROTOCOL.GetImageInfo(),https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol-getimageinfo
-23.1.3,EFI_FIRMWARE_MANAGEMENT_PROTOCOL.GetImage(),https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol-getimage
-23.1.4,EFI_FIRMWARE_MANAGEMENT_PROTOCOL.SetImage(),https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol-setimage
-23.1.5,EFI_FIRMWARE_MANAGEMENT_PROTOCOL.CheckImage(),https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol-checkimage
-23.1.6,EFI_FIRMWARE_MANAGEMENT_PROTOCOL.GetPackageInfo(),https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol-getpackageinfo
-23.1.7,EFI_FIRMWARE_MANAGEMENT_PROTOCOL.SetPackageInfo(),https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol-setpackageinfo
-23.2,Dependency Expression Instruction Set,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#dependency-expression-instruction-set
-23.2.1,PUSH_GUID,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#push-guid
-23.2.2,PUSH_VERSION,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#push-version
-23.2.3,DECLARE_VERSION_NAME,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#declare-version-name
-23.2.4,AND,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#and
-23.2.5,OR,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#or
-23.2.6,NOT,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#not
-23.2.7,TRUE,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#true
-23.2.8,FALSE,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#false
-23.2.9,EQ,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#eq
-23.2.10,GT,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#gt
-23.2.11,GTE,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#gte
-23.2.12,LT,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#lt
-23.2.13,LTE,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#lte
-23.2.14,END,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#end
-23.2.15,DECLARE_LENGTH,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#declare-length
-23.3,Delivering Capsules Containing Updates toFirmware Management Protocol,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#delivering-capsules-containing-updates-tofirmware-management-protocol
-23.3.1,EFI_FIRMWARE_MANAGEMENT_CAPSULE_ID_GUID,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#efi-firmware-management-capsule-id-guid
-23.3.2,DEFINED FIRMWARE MANAGEMENT PROTOCOL DATA CAPSULE STRUCTURE,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#defined-firmware-management-protocol-data-capsule-structure
-23.3.3,Firmware Processing of the Capsule Identified by EFI_FIRMWARE_MANAGEMENT_CAPSULE_ID_GUID,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#firmware-processing-of-the-capsule-identified-by-efi-firmware-management-capsule-id-guid
-23.4,EFI System Resource Table,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#efi-system-resource-table
-23.4.1,EFI_SYSTEM_RESOURCE_TABLE,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#id29
-23.4.2,Adding and Removing Devices from the ESRT,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#adding-and-removing-devices-from-the-esrt
-23.4.3,ESRT and Firmware Management Protocol,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#esrt-and-firmware-management-protocol
-23.4.4,Mapping Firmware Management Protocol Descriptors to ESRT Entries,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#mapping-firmware-management-protocol-descriptors-to-esrt-entries
-23.5,Delivering Capsule Containing JSON payload,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#delivering-capsule-containing-json-payload
-23.5.1,EFI_JSON_CAPSULE_ID_GUID,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#efi-json-capsule-id-guid
-23.5.2,Defined JSON Capsule Data Structure,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#defined-json-capsule-data-structure
-23.5.3,Firmware Processing of the Capsule Identified by EFI_JSON_CAPSULE_ID_GUID,https://uefi.org/specs/UEFI/2.10_A/23_Firmware_Update_and_Reporting.html#firmware-processing-of-the-capsule-identified-by-efi-json-capsule-id-guid
-24,"Network Protocols - SNP, PXE, BIS and HTTP Boot",https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html
-24.1,Simple Network Protocol,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#simple-network-protocol
-24.1.1,EFI_SIMPLE_NETWORK_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-protocol
-24.1.2,EFI_SIMPLE_NETWORK.Start(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-start
-24.1.3,EFI_SIMPLE_NETWORK.Stop(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-stop
-24.1.4,EFI_SIMPLE_NETWORK.Initialize(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-initialize
-24.1.5,EFI_SIMPLE_NETWORK.Reset(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-reset
-24.1.6,EFI_SIMPLE_NETWORK.Shutdown(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-shutdown
-24.1.7,EFI_SIMPLE_NETWORK.ReceiveFilters(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-receivefilters
-24.1.8,EFI_SIMPLE_NETWORK.StationAddress(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-stationaddress
-24.1.9,EFI_SIMPLE_NETWORK.Statistics(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-statistics
-24.1.10,EFI_SIMPLE_NETWORK.MCastIPtoMAC(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-mcastiptomac
-24.1.11,EFI_SIMPLE_NETWORK.NvData(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-nvdata
-24.1.12,EFI_SIMPLE_NETWORK.GetStatus(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-getstatus
-24.1.13,EFI_SIMPLE_NETWORK.Transmit(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-transmit
-24.1.14,EFI_SIMPLE_NETWORK.Receive(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-receive
-24.2,Network Interface Identifier Protocol,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#network-interface-identifier-protocol
-24.2.1,EFI_NETWORK_INTERFACE_IDENTIFIER_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-network-interface-identifier-protocol
-24.3,PXE Base Code Protocol,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#pxe-base-code-protocol
-24.3.1,EFI_PXE_BASE_CODE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol
-24.3.2,DHCP Packet Data Types,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#dhcp-packet-data-types
-24.3.3,IP Receive Filter Settings,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#ip-receive-filter-settings
-24.3.4,ARP Cache Entries,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#arp-cache-entries
-24.3.5,Filter Operations for UDP Read/Write Functions,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#filter-operations-for-udp-read-write-functions
-24.3.6,EFI_PXE_BASE_CODE_PROTOCOL.Start(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-start
-24.3.7,EFI_PXE_BASE_CODE_PROTOCOL.Stop(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-stop
-24.3.8,EFI_PXE_BASE_CODE_PROTOCOL.Dhcp(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-dhcp
-24.3.9,EFI_PXE_BASE_CODE_PROTOCOL.Discover(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-discover
-24.3.10,EFI_PXE_BASE_CODE_PROTOCOL.Mtftp(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-mtftp
-24.3.11,EFI_PXE_BASE_CODE_PROTOCOL.UdpWrite(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-udpwrite
-24.3.12,EFI_PXE_BASE_CODE_PROTOCOL.UdpRead(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-udpread
-24.3.13,EFI_PXE_BASE_CODE_PROTOCOL.SetIpFilter(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-setipfilter
-24.3.14,EFI_PXE_BASE_CODE_PROTOCOL.Arp(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-arp
-24.3.15,EFI_PXE_BASE_CODE_PROTOCOL.SetParameters(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-setparameters
-24.3.16,EFI_PXE_BASE_CODE_PROTOCOL.SetStationIp(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-setstationip
-24.3.17,EFI_PXE_BASE_CODE_PROTOCOL.SetPackets(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-setpackets
-24.3.18,Netboot6,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#netboot6
-24.3.18.1,DHCP6 options for PXE,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#dhcp6-options-for-pxe
-24.3.18.2,IPv6-based PXE boot,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#ipv6-based-pxe-boot
-24.3.18.3,Proxy DHCP6,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#proxy-dhcp6
-24.4,PXE Base Code Callback Protocol,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#pxe-base-code-callback-protocol
-24.4.1,EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-callback-protocol
-24.4.2,EFI_PXE_BASE_CODE_CALLBACK.Callback(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-callback-callback
-24.5,Boot Integrity Services Protocol,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#boot-integrity-services-protocol
-24.5.1,EFI_BIS_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol
-24.5.2,EFI_BIS_PROTOCOL.Initialize(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-initialize
-24.5.3,EFI_BIS_PROTOCOL.Shutdown(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-shutdown
-24.5.4,EFI_BIS_PROTOCOL.Free(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-free
-24.5.5,EFI_BIS_PROTOCOL.GetBootObjectAuthorizationCertificate(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-getbootobjectauthorizationcertificate
-24.5.6,EFI_BIS_PROTOCOL.GetBootObjectAuthorizationCheckFlag(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-getbootobjectauthorizationcheckflag
-24.5.7,EFI_BIS_PROTOCOL.GetBootObjectAuthorizationUpdateToken(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-getbootobjectauthorizationupdatetoken
-24.5.8,EFI_BIS_PROTOCOL.GetSignatureInfo(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-getsignatureinfo
-24.5.9,EFI_BIS_PROTOCOL.UpdateBootObjectAuthorization(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-updatebootobjectauthorization
-24.5.10,EFI_BIS_PROTOCOL.VerifyBootObject(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-verifybootobject
-24.5.11,EFI_BIS_PROTOCOL.VerifyObjectWithCredential(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-verifyobjectwithcredential
-24.6,DHCP options for ISCSI on IPV6,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#dhcp-options-for-iscsi-on-ipv6
-24.7,HTTP Boot,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#http-boot
-24.7.1,Boot from URL,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#boot-from-url
-24.7.2,Concept configuration for a typical HTTP Bootscenario,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#concept-configuration-for-a-typical-http-bootscenario
-24.7.2.1,Use in Corporate environment,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#use-in-corporate-environment
-24.7.2.2,Use case in Home environment,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#use-case-in-home-environment
-24.7.3,Protocol Layout for UEFI HTTP Boot Clientconcept configuration for a typical HTTP Boot scenario,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#protocol-layout-for-uefi-http-boot-clientconcept-configuration-for-a-typical-http-boot-scenario
-24.7.3.1,Device Path,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#device-path
-24.7.4,Concept of Message Exchange in a typical HTTPBoot scenario (IPv4 in Corporate Environment),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#concept-of-message-exchange-in-a-typical-httpboot-scenario-ipv4-in-corporate-environment
-24.7.4.1,Message exchange between EFI Client and DHCPserver using DHCP Client Extensions,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#message-exchange-between-efi-client-and-dhcpserver-using-dhcp-client-extensions
-24.7.5,Priority1,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#priority1
-24.7.6,Priority2,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#priority2
-24.7.7,Priority3,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#priority3
-24.7.8,Priority4,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#priority4
-24.7.8.1,Message exchange between UEFI Client and DHCPserver not using DHCP Client Extensions,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#message-exchange-between-uefi-client-and-dhcpserver-not-using-dhcp-client-extensions
-24.7.8.2,Message in DNS Query/Reply,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#message-in-dns-query-reply
-24.7.8.3,Message in HTTP Download,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#message-in-http-download
-24.7.9,Concept of Message Exchange in HTTP Bootscenario (IPv6),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#concept-of-message-exchange-in-http-bootscenario-ipv6
-24.7.9.1,Message exchange between EFI Client andDHCPv6 server with DHCP Client extensions,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#message-exchange-between-efi-client-anddhcpv6-server-with-dhcp-client-extensions
-24.7.9.2,Message exchange between UEFI Client andDHCPv6 server not using DHCP Client Extensions,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#message-exchange-between-uefi-client-anddhcpv6-server-not-using-dhcp-client-extensions
-24.7.9.3,Message exchange between UEFI Client and DNS6server,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#message-exchange-between-uefi-client-and-dns6server
-24.7.9.4,Message in HTTP Download,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#message-in-http-download-2
-24.7.10,EFI HTTP Boot Callback Protocol,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-http-boot-callback-protocol
-24.7.11,EFI_HTTP_BOOT_CALLBACK_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-http-boot-callback-protocol-1
-24.7.12,EFI_HTTP_BOOT_CALLBACK_PROTOCOL.Callback(),https://uefi.org/specs/UEFI/2.10_A/24_Network_Protocols_SNP_PXE_BIS.html#efi-http-boot-callback-protocol-callback
-25,Network Protocols - Managed Network,https://uefi.org/specs/UEFI/2.10_A/25_Network_Protocols_Managed_Network.html
-25.1,EFI Managed Network Protocol,https://uefi.org/specs/UEFI/2.10_A/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol
-25.1.1,EFI_MANAGED_NETWORK_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/25_Network_Protocols_Managed_Network.html#efi-managed-network-service-binding-protocol
-25.1.2,EFI_MANAGED_NETWORK_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/25_Network_Protocols_Managed_Network.html#id4
-25.1.3,EFI_MANAGED_NETWORK_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-getmodedata
-25.1.4,EFI_MANAGED_NETWORK_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-configure
-25.1.5,EFI_MANAGED_NETWORK_PROTOCOL.McastIpToMac(),https://uefi.org/specs/UEFI/2.10_A/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-mcastiptomac
-25.1.6,EFI_MANAGED_NETWORK_PROTOCOL.Groups(),https://uefi.org/specs/UEFI/2.10_A/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-groups
-25.1.7,EFI_MANAGED_NETWORK_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.10_A/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-transmit
-25.1.8,EFI_MANAGED_NETWORK_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.10_A/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-receive
-25.1.9,EFI_MANAGED_NETWORK_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.10_A/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-cancel
-25.1.10,EFI_MANAGED_NETWORK_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.10_A/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-poll
-26,Network Protocols - Bluetooth,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html
-26.1,EFI Bluetooth Host Controller Protocol,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#efi-bluetooth-host-controller-protocol
-26.1.1,EFI_BLUETOOTH_HC_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#efi-bluetooth-hc-protocol
-26.1.2,BLUETOOTH_HC_PROTOCOL.SendCommand(),https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-sendcommand
-26.1.3,BLUETOOTH_HC_PROTOCOL.ReceiveEvent(),https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-receiveevent
-26.1.4,BLUETOOTH_HC_PROTOCOL.AsyncReceiveEvent(),https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-asyncreceiveevent
-26.1.5,BLUETOOTH_HC_PROTOCOL.SendACLData(),https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-sendacldata
-26.1.6,BLUETOOTH_HC_PROTOCOL.ReceiveACLData(),https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-receiveacldata
-26.1.7,BLUETOOTH_HC_PROTOCOL.AsyncReceiveACLData(),https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-asyncreceiveacldata
-26.1.8,BLUETOOTH_HC_PROTOCOL.SendSCOData(),https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-sendscodata
-26.1.9,BLUETOOTH_HC_PROTOCOL.ReceiveSCOData(),https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-receivescodata
-26.1.10,BLUETOOTH_HC_PROTOCOL.AsyncReceiveSCOData(),https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-asyncreceivescodata
-26.2,EFI Bluetooth Bus Protocol,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#efi-bluetooth-bus-protocol
-26.2.1,EFI_BLUETOOTH_IO_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#efi-bluetooth-io-service-binding-protocol
-26.2.2,EFI_BLUETOOTH_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#efi-bluetooth-io-protocol
-26.2.3,BLUETOOTH_IO_PROTOCOL.GetDeviceInfo,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-getdeviceinfo
-26.2.4,BLUETOOTH_IO_PROTOCOL.GetSdpInfo,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-getsdpinfo
-26.2.5,BLUETOOTH_IO_PROTOCOL.L2CapRawSend,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2caprawsend
-26.2.6,BLUETOOTH_IO_PROTOCOL.L2CapRawReceive,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2caprawreceive
-26.2.7,BLUETOOTH_IO_PROTOCOL.L2CapRawAsyncReceive,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2caprawasyncreceive
-26.2.8,BLUETOOTH_IO_PROTOCOL.L2CapSend,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2capsend
-26.2.9,BLUETOOTH_IO_PROTOCOL.L2CapReceive,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2capreceive
-26.2.10,BLUETOOTH_IO_PROTOCOL.L2CapAsyncReceive,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2capasyncreceive
-26.2.11,BLUETOOTH_IO_PROTOCOL.L2CapConnect,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2capconnect
-26.2.12,BLUETOOTH_IO_PROTOCOL.L2CapDisconnect,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2capdisconnect
-26.2.13,BLUETOOTH_IO_PROTOCOL.L2CapRegisterService,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2capregisterservice
-26.3,EFI Bluetooth Configuration Protocol,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#efi-bluetooth-configuration-protocol
-26.3.1,EFI_BLUETOOTH_CONFIG_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#efi-bluetooth-config-protocol
-26.3.2,BLUETOOTH_CONFIG_PROTOCOL.Init,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-init
-26.3.3,BLUETOOTH_CONFIG_PROTOCOL.Scan,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-scan
-26.3.4,BLUETOOTH_CONFIG_PROTOCOL.Connect,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-connect
-26.3.5,BLUETOOTH_CONFIG_PROTOCOL.Disconnect,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-disconnect
-26.3.6,BLUETOOTH_CONFIG_PROTOCOL.GetData,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-getdata
-26.3.7,BLUETOOTH_CONFIG_PROTOCOL.SetData,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-setdata
-26.3.8,BLUETOOTH_CONFIG_PROTOCOL.GetRemoteData,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-getremotedata
-26.3.9,BLUETOOTH_CONFIG_PROTOCOL.RegisterPinCallback,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-registerpincallback
-26.3.10,BLUETOOTH_CONFIG_PROTOCOL.RegisterGetLinkKeyCallback,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-registergetlinkkeycallback
-26.3.11,BLUETOOTH_CONFIG_PROTOCOL.RegisterSetLinkKeyCallback,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-registersetlinkkeycallback
-26.3.12,BLUETOOTH_CONFIG_PROTOCOL.RegisterLinkConnectCompleteCallback,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-registerlinkconnectcompletecallback
-26.4,EFI Bluetooth Attribute Protocol,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#efi-bluetooth-attribute-protocol
-26.4.1,EFI_BLUETOOTH_ATTRIBUTE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#id41
-26.4.2,BLUETOOTH_ATTRIBUTE_PROTOCOL.SendRequest,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-attribute-protocol-sendrequest
-26.4.3,BLUETOOTH_ATTRIBUTE_PROTOCOL.RegisterForServerNotification,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-attribute-protocol-registerforservernotification
-26.4.4,BLUETOOTH_ATTRIBUTE_PROTOCOL.GetServiceInfo,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-attribute-protocol-getserviceinfo
-26.4.5,BLUETOOTH_ATTRIBUTE_PROTOCOL.GetDeviceInfo,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-attribute-protocol-getdeviceinfo
-26.4.6,EFI_BLUETOOTH_ATTRIBUTE_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#efi-bluetooth-attribute-service-binding-protocol
-26.5,EFI Bluetooth LE Configuration Protocol,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#efi-bluetooth-le-configuration-protocol
-26.5.1,EFI_BLUETOOTH_LE_CONFIG_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#efi-bluetooth-le-config-protocol
-26.5.2,BLUETOOTH_LE_CONFIG_PROTOCOL.Init,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-init
-26.5.3,BLUETOOTH_LE_CONFIG_PROTOCOL.Scan,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-scan
-26.5.4,BLUETOOTH_LE_CONFIG_PROTOCOL.Connect,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-connect
-26.5.5,BLUETOOTH_LE_CONFIG_PROTOCOL.Disconnect,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-disconnect
-26.5.6,BLUETOOTH_LE_CONFIG_PROTOCOL.GetData,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-getdata
-26.5.7,BLUETOOTH_LE_CONFIG_PROTOCOL.SetData,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-setdata
-26.5.8,BLUETOOTH_LE_CONFIG_PROTOCOL.GetRemoteData,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-getremotedata
-26.5.9,BLUETOOTH_LE_CONFIG_PROTOCOL.RegisterSmpAuthCallback,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-registersmpauthcallback
-26.5.10,BLUETOOTH_LE_CONFIG_PROTOCOL.SendSmpAuthData,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-sendsmpauthdata
-26.5.11,BLUETOOTH_LE_CONFIG_PROTOCOL.RegisterSmpGetDataCallback,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-registersmpgetdatacallback
-26.5.12,BLUETOOTH_LE_CONFIG_PROTOCOL.RegisterSmpSetDataCallback,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-registersmpsetdatacallback
-26.5.13,BLUETOOTH_LE_CONFIG_PROTOCOL.RegisterLinkConnectCompleteCallback,https://uefi.org/specs/UEFI/2.10_A/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-registerlinkconnectcompletecallback
-27,"Network Protocols - VLAN, EAP, Wi-Fi and Supplicant",https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html
-27.1,VLAN Configuration Protocol,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#vlan-configuration-protocol
-27.1.1,EFI_VLAN_CONFIG_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-vlan-config-protocol
-27.1.2,EFI_VLAN_CONFIG_PROTOCOL.Set(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-vlan-config-protocol-set
-27.1.3,EFI_VLAN_CONFIG_PROTOCOL.Find(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-vlan-config-protocol-find
-27.1.4,EFI_VLAN_CONFIG_PROTOCOL.Remove(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-vlan-config-protocol-remove
-27.2,EAP Protocol,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#eap-protocol
-27.2.1,EFI_EAP_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-protocol
-27.2.2,EFI_EAP.SetDesiredAuthMethod(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-setdesiredauthmethod
-27.2.3,EFI_EAP.RegisterAuthMethod(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-registerauthmethod
-27.2.4,EAPManagement Protocol,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#eapmanagement-protocol
-27.2.5,EFI_EAP_MANAGEMENT_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-protocol
-27.2.6,EFI_EAP_MANAGEMENT.GetSystemConfiguration(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-getsystemconfiguration
-27.2.7,EFI_EAP_MANAGEMENT.SetSystemConfiguration(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-setsystemconfiguration
-27.2.8,EFI_EAP_MANAGEMENT.InitializePort(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-initializeport
-27.2.9,EFI_EAP_MANAGEMENT.UserLogon(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-userlogon
-27.2.10,EFI_EAP_MANAGEMENT.UserLogoff(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-userlogoff
-27.2.11,EFI_EAP_MANAGEMENT.GetSupplicantStatus(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-getsupplicantstatus
-27.2.12,EFI_EAP_MANAGEMENT.SetSupplicantConfiguration(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-setsupplicantconfiguration
-27.2.13,EFI_EAP_MANAGEMENT.GetSupplicantStatistics(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-getsupplicantstatistics
-27.2.14,EFI EAP Management2 Protocol,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management2-protocol
-27.2.14.1,EFI_EAP_MANAGEMENT2_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#id21
-27.2.15,EFI_EAP_MANAGEMENT2_PROTOCOL.GetKey(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management2-protocol-getkey
-27.2.16,EFI EAP Configuration Protocol,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-configuration-protocol
-27.2.16.1,EFI_EAP_CONFIGURATION_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#id24
-27.2.17,EFI_EAP_CONFIGURATION_PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-configuration-protocol-setdata
-27.2.18,EFI_EAP_CONFIGURATION_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-configuration-protocol-getdata
-27.3,EFI Wireless MAC Connection Protocol,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-protocol
-27.3.1,EFI_WIRELESS_MAC_CONNECTION_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#id28
-27.3.2,EFI_WIRELESS_MAC_CONNECTION_PROTOCOL.Scan(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-protocol-scan
-27.3.3,EFI_WIRELESS_MAC_CONNECTION_PROTOCOL.Associate(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-protocol-associate
-27.3.4,EFI_WIRELESS_MAC_CONNECTION_PROTOCOL.Disassociate(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-protocol-disassociate
-27.3.5,EFI_WIRELESS_MAC_CONNECTION_PROTOCOL.Authenticate(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-protocol-authenticate
-27.3.6,EFI_WIRELESS_MAC_CONNECTION_PROTOCOL.Deauthenticate(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-protocol-deauthenticate
-27.4,EFI Wireless MAC Connection II Protocol,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-ii-protocol
-27.4.1,EFI_WIRELESS_MAC_CONNECTION_II_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#id35
-27.4.2,EFI_WIRELESS_MAC_CONNECTION_II_PROTOCOL.GetNetworks(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-ii-protocol-getnetworks
-27.4.3,EFI_WIRELESS_MAC_CONNECTION_II_PROTOCOL.ConnectNetwork(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-ii-protocol-connectnetwork
-27.4.4,EFI_WIRELESS_MAC_CONNECTION_II_PROTOCOL.DisconnectNetwork(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-ii-protocol-disconnectnetwork
-27.5,EFI Supplicant Protocol,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-protocol
-27.5.1,Supplicant Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#supplicant-service-binding-protocol
-27.5.2,EFI_SUPPLICANT_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-service-binding-protocol
-27.5.3,Supplicant Protocol,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#supplicant-protocol
-27.5.4,EFI_SUPPLICANT_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-protocol-network-protocols-vlan-and-eap
-27.5.5,EFI_SUPPLICANT_PROTOCOL.BuildResponsePacket(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-protocol-buildresponsepacket
-27.5.6,EFI_SUPPLICANT_PROTOCOL.ProcessPacket(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-protocol-processpacket
-27.5.7,EFI_SUPPLICANT_PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-protocol-setdata
-27.5.8,EFI_SUPPLICANT_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.10_A/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-protocol-getdata
-28,"Network Protocols - TCP, IP, IPsec, FTP, TLS and Configurations",https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html
-28.1,EFI TCPv4 Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcpv4-protocol
-28.1.1,TCP4 Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#tcp4-service-binding-protocol
-28.1.2,EFI_TCP4_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-service-binding-protocol
-28.1.3,TCP4 Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#tcp4-protocol
-28.1.4,EFI_TCP4_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol
-28.1.5,EFI_TCP4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-getmodedata
-28.1.6,EFI_TCP4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-configure
-28.1.7,EFI_TCP4_PROTOCOL.Routes(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-routes
-28.1.8,EFI_TCP4_PROTOCOL.Connect(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-connect
-28.1.9,EFI_TCP4_PROTOCOL.Accept(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-accept
-28.1.10,EFI_TCP4_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-transmit
-28.1.10.1,EFI_TCP4_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-receive
-28.1.11,EFI_TCP4_PROTOCOL.Close(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-close
-28.1.12,EFI_TCP4_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-cancel
-28.1.13,EFI_TCP4_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-poll
-28.2,EFI TCPv6 Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcpv6-protocol
-28.2.1,TCPv6 Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#tcpv6-service-binding-protocol
-28.2.2,EFI_TCP6_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-service-binding-protocol
-28.2.3,TCPv6 Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#tcpv6-protocol
-28.2.4,EFI_TCP6_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol
-28.2.5,EFI_TCP6_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-getmodedata
-28.2.6,EFI_TCP6_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-configure
-28.2.7,EFI_TCP6_PROTOCOL.Connect(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-connect
-28.2.8,EFI_TCP6_PROTOCOL.Accept(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-accept
-28.2.9,EFI_TCP6_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-transmit
-28.2.10,EFI_TCP6_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-receive
-28.2.11,EFI_TCP6_PROTOCOL.Close(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-close
-28.2.12,EFI_TCP6_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-cancel
-28.2.13,EFI_TCP6_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-poll
-28.3,EFI IPv4 Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipv4-protocol
-28.3.1,IP4 Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#ip4-service-binding-protocol
-28.3.2,EFI_IP4_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-service-binding-protocol
-28.3.3,IP4 Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#ip4-protocol
-28.3.4,EFI_IP4_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol
-28.3.5,EFI_IP4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-getmodedata
-28.3.6,EFI_IP4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-configure
-28.3.7,EFI_IP4_PROTOCOL.Groups(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-groups
-28.3.8,EFI_IP4_PROTOCOL.Routes(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-routes
-28.3.9,EFI_IP4_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-transmit
-28.3.10,EFI_IP4_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-receive
-28.3.11,EFI_IP4_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-cancel
-28.3.12,EFI_IP4_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-poll
-28.4,EFI IPv4 Configuration II Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipv4-configuration-ii-protocol
-28.4.1,EFI_IP4_CONFIG2_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-config2-protocol
-28.4.2,EFI_IP4_CONFIG2_PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-config2-protocol-setdata
-28.4.3,EFI_IP4_CONFIG2_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-config2-protocol-getdata
-28.4.4,EFI_IP4_CONFIG2_PROTOCOL.RegisterDataNotify (),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-config2-protocol-registerdatanotify
-28.4.5,EFI_IP4_CONFIG2_PROTOCOL.UnregisterDataNotify (),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-config2-protocol-unregisterdatanotify
-28.5,EFI IPv6 Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipv6-protocol
-28.5.1,IPv6 Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#ipv6-service-binding-protocol
-28.5.2,EFI_IP6_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-service-binding-protocol
-28.5.3,IPv6 Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#ipv6-protocol
-28.5.4,EFI_IP6_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol
-28.5.5,EFI_IP6_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-getmodedata
-28.5.6,EFI_IP6_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-configure
-28.5.7,EFI_IP6_PROTOCOL.Groups(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-groups
-28.5.8,EFI_IP6_PROTOCOL.Routes(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-routes
-28.5.9,EFI_IP6_PROTOCOL.Neighbors(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-neighbors
-28.5.10,EFI_IP6_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-transmit
-28.5.11,EFI_IP6_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-receive
-28.5.12,EFI_IP6_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-cancel
-28.5.13,EFI_IP6_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-poll
-28.6,EFI IPv6 Configuration Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipv6-configuration-protocol
-28.6.1,EFI_IP6_CONFIG_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-config-protocol
-28.6.2,EFI_IP6_CONFIG_PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-config-protocol-setdata
-28.6.3,EFI_IP6_CONFIG_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-config-protocol-getdata
-28.6.4,EFI_IP6_CONFIG_PROTOCOL.RegisterDataNotify (),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-config-protocol-registerdatanotify
-28.6.5,EFI_IP6_CONFIG_PROTOCOL.UnregisterDataNotify(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-config-protocol-unregisterdatanotify
-28.7,IPsec,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#ipsec
-28.7.1,IPsec Overview,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#ipsec-overview
-28.7.2,EFI IPsec Configuration Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-configuration-protocol
-28.7.3,EFI_IPSEC_CONFIG_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-config-protocol
-28.7.4,EFI_IPSEC_CONFIG_PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-config-protocol-setdata
-28.7.5,EFI_IPSEC_CONFIG_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-config-protocol-getdata
-28.7.6,EFI_IPSEC_CONFIG_PROTOCOL.GetNextSelector(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-config-protocol-getnextselector
-28.7.7,EFI_IPSEC_CONFIG_PROTOCOL.RegisterDataNotify (),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-config-protocol-registerdatanotify
-28.7.8,EFI_IPSEC_CONFIG_PROTOCOL.UnregisterDataNotify (),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-config-protocol-unregisterdatanotify
-28.7.9,EFI IPsec Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-protocol
-28.7.10,EFI_IPSEC_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#id79
-28.7.11,EFI_IPSEC_PROTOCOL.Process(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-protocol-process
-28.7.12,EFI IPsec2 Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec2-protocol
-28.7.13,EFI_IPSEC2_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#id83
-28.7.14,EFI_IPSEC2_PROTOCOL.ProcessExt(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec2-protocol-processext
-28.8,Network Protocol - EFI FTP Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#network-protocol-efi-ftp-protocol
-28.8.1,EFI_FTP4_SERVICE_BINDING_PROTOCOL Summary,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-service-binding-protocol-summary
-28.8.2,EFI_FTP4_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol
-28.8.3,EFI_FTP4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-getmodedata
-28.8.4,EFI_FTP4_PROTOCOL.Connect(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-connect
-28.8.5,EFI_FTP4_PROTOCOL.Close(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-close
-28.8.6,EFI_FTP4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-configure
-28.8.7,EFI_FTP4_PROTOCOL.ReadFile(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-readfile
-28.8.8,EFI_FTP4_PROTOCOL.WriteFile(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-writefile
-28.8.9,EFI_FTP4_PROTOCOL.ReadDirectory(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-readdirectory
-28.8.10,EFI_FTP4_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-poll
-28.9,EFI TLS Protocols,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-protocols
-28.9.1,EFI TLS Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-service-binding-protocol
-28.9.1.1,EFI_TLS_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#id99
-28.9.2,EFI TLS Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-protocol
-28.9.2.1,EFI_TLS_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#id101
-28.9.3,EFI_TLS_PROTOCOL.SetSessionData (),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-protocol-setsessiondata
-28.9.4,EFI_TLS_PROTOCOL.GetSessionData (),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-protocol-getsessiondata
-28.9.5,EFI_TLS_PROTOCOL.BuildResponsePacket (),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-protocol-buildresponsepacket
-28.9.6,EFI_TLS_PROTOCOL.ProcessPacket (),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-protocol-processpacket
-28.9.7,EFI TLS Configuration Protocol,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-configuration-protocol
-28.9.7.1,EFI_TLS_CONFIGURATION_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#id107
-28.9.8,EFI_TLS_CONFIGURATION_PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-configuration-protocol-setdata
-28.9.9,EFI_TLS_CONFIGURATION_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.10_A/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-configuration-protocol-getdata
-29,"Network Protocols - ARP, DHCP, DNS, HTTP and REST",https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html
-29.1,ARP Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#arp-protocol
-29.1.1,EFI_ARP_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-service-binding-protocol
-29.1.2,EFI_ARP_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol
-29.1.3,EFI_ARP_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-configure
-29.1.4,EFI_ARP_PROTOCOL.Add(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-add
-29.1.5,EFI_ARP_PROTOCOL.Find(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-find
-29.1.6,EFI_ARP_PROTOCOL.Delete(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-delete
-29.1.7,EFI_ARP_PROTOCOL.Flush(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-flush
-29.1.8,EFI_ARP_PROTOCOL.Request(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-request
-29.1.9,EFI_ARP_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-cancel
-29.2,EFI DHCPv4 Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcpv4-protocol
-29.2.1,EFI_DHCP4_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-service-binding-protocol
-29.2.2,EFI_DHCP4_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol
-29.2.3,EFI_DHCP4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-getmodedata
-29.2.4,EFI_DHCP4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-configure
-29.2.5,EFI_DHCP4_PROTOCOL.Start(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-start
-29.2.6,EFI_DHCP4_PROTOCOL.RenewRebind(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-renewrebind
-29.2.7,EFI_DHCP4_PROTOCOL.Release(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-release
-29.2.8,EFI_DHCP4_PROTOCOL.Stop(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-stop
-29.2.9,EFI_DHCP4_PROTOCOL.Build(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-build
-29.2.10,EFI_DHCP4_PROTOCOL.TransmitReceive(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-transmitreceive
-29.2.11,EFI_DHCP4_PROTOCOL.Parse(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-parse
-29.3,EFI DHCP6 Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol
-29.3.1,DHCP6 Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#dhcp6-service-binding-protocol
-29.3.2,EFI_DHCP6_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-service-binding-protocol
-29.3.3,DHCP6 Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#dhcp6-protocol
-29.3.4,EFI_DHCP6_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#id27
-29.3.5,EFI_DHCP6_PROTOCOL.GetModeData (),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-getmodedata
-29.3.6,EFI_DHCP6_PROTOCOL.Configure (),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-configure
-29.3.7,EFI_DHCP6_PROTOCOL.Start (),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-start
-29.3.8,EFI_DHCP6_PROTOCOL.InfoRequest (),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-inforequest
-29.3.9,EFI_DHCP6_PROTOCOL.RenewRebind (),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-renewrebind
-29.3.10,EFI_DHCP6_PROTOCOL.Decline (),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-decline
-29.3.11,EFI_DHCP6_PROTOCOL.Release (),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-release
-29.3.12,EFI_DHCP6_PROTOCOL.Stop (),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-stop
-29.3.13,EFI_DHCP6_PROTOCOL.Parse (),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-parse
-29.4,EFI DNSv4 Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dnsv4-protocol
-29.4.1,EFI_DNS4_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-service-binding-protocol
-29.4.2,EFI_DNS4_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol
-29.4.3,EFI_DNS4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-getmodedata
-29.4.4,EFI_DNS4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-configure
-29.4.5,EFI_DNS4_PROTOCOL.HostNameToIp(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-hostnametoip
-29.4.6,EFI_DNS4_PROTOCOL.IpToHostName(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-iptohostname
-29.4.7,EFI_DNS4_PROTOCOL.GeneralLookUp(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-generallookup
-29.4.8,EFI_DNS4_PROTOCOL.UpdateDnsCache(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-updatednscache
-29.4.9,EFI_DNS4_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-poll
-29.4.10,EFI_DNS4_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-cancel
-29.5,EFI DNSv6 Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dnsv6-protocol
-29.5.1,DNS6 Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#dns6-service-binding-protocol
-29.5.2,EFI_DNS6_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-service-binding-protocol
-29.5.3,DNS6 Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#dns6-protocol
-29.5.4,EFI_DNS6_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol
-29.5.5,EFI_DNS6_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-getmodedata
-29.5.6,EFI_DNS6_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-configure
-29.5.7,EFI_DNS6_PROTOCOL.HostNameToIp(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-hostnametoip
-29.5.8,EFI_DNS6_PROTOCOL.IpToHostName(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-iptohostname
-29.5.9,EFI_DNS6_PROTOCOL.GeneralLookUp(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-generallookup
-29.5.10,EFI_DNS6_PROTOCOL.UpdateDnsCache(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-updatednscache
-29.5.11,EFI_DNS6_PROTOCOL.POLL(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-poll
-29.5.12,EFI_DNS6_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-cancel
-29.6,EFI HTTP Protocols,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocols
-29.6.1,HTTP Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#http-service-binding-protocol
-29.6.1.1,EFI_HTTP_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-http-service-binding-protocol
-29.6.2,EFI HTTP Protocol Specific Definitions,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-specific-definitions
-29.6.3,EFI_HTTP_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol
-29.6.4,EFI_HTTP_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-getmodedata
-29.6.5,EFI_HTTP_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-configure
-29.6.6,EFI_HTTP_PROTOCOL.Request(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-request
-29.6.7,EFI_HTTP_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-cancel
-29.6.8,EFI_HTTP_PROTOCOL.Response(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-response
-29.6.9,EFI_HTTP_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-poll
-29.6.9.1,Usage Examples,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#usage-examples
-29.6.10,HTTP Utilities Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#http-utilities-protocol
-29.6.11,EFI_HTTP_UTILITIES_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-http-utilities-protocol
-29.6.12,EFI_HTTP_UTILITIES_PROTOCOL.Build(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-http-utilities-protocol-build
-29.6.13,EFI_HTTP_UTILITIES_PROTOCOL.Parse(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-http-utilities-protocol-parse
-29.7,EFI REST Support Overview,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-support-overview
-29.7.1,EFI REST Support Scenario 1 (PlatformManagement),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-support-scenario-1-platformmanagement
-29.7.2,EFI REST Support Scenario 2 (PlatformManagement),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-support-scenario-2-platformmanagement
-29.7.3,EFI REST Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-protocol
-29.7.3.1,EFI REST Protocol Definitions,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-protocol-definitions
-29.7.4,EFI_REST_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#id81
-29.7.5,EFI_REST_PROTOCOL.SendReceive(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-protocol-sendreceive
-29.7.6,EFI_REST_PROTOCOL.GetServiceTime(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-protocol-getservicetime
-29.7.7,EFI REST EX Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol
-29.7.7.1,REST EX Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#rest-ex-service-binding-protocol
-29.7.8,EFI_REST_EX_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-service-binding-protocol
-29.7.8.1,REST EX Protocol Specific Definitions,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#rest-ex-protocol-specific-definitions
-29.7.9,EFI_REST_EX_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#id88
-29.7.10,EFI_REST_EX_PROTOCOL.SendReceive(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol-sendreceive
-29.7.11,EFI_REST_EX_PROTOCOL.GetService(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol-getservice
-29.7.12,EFI_REST_EX_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol-getmodedata
-29.7.13,EFI_REST_EX_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol-configure
-29.7.14,EFI_REST_EX_PROTOCOL.AsyncSendReceive(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol-asyncsendreceive
-29.7.15,EFI_REST_EX_PROTOCOL.EventService(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol-eventservice
-29.7.15.1,Usage Example (HTTP-aware REST EX Protocol DriverInstance),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#usage-example-http-aware-rest-ex-protocol-driverinstance
-29.7.16,EFI_REST_EX_PROTOCOL.EventService(),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#id98
-29.7.17,EFI REST JSON Resource to C Structure Converter,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-json-resource-to-c-structure-converter
-29.7.17.1,Overview,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#overview
-29.7.17.2,EFI REST JSON Structure Protocol,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-json-structure-protocol
-29.7.18,EFI_REST_JSON_STRUCTURE.Register (),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-json-structure-register
-29.7.19,EFI_REST_JSON_STRUCTURE.ToStructure (),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-json-structure-tostructure
-29.7.20,EFI_REST_JSON_STRUCTURE.ToJson (),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-json-structure-tojson
-29.7.21,EFI_REST_JSON_STRUCTURE.DestroyStructure (),https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-json-structure-destroystructure
-29.7.21.1,EFI Redfish JSON Structure Converter,https://uefi.org/specs/UEFI/2.10_A/29_Network_Protocols_ARP_and_DHCP.html#efi-redfish-json-structure-converter
-30,Network Protocols - UDP and MTFTP,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html
-30.1,EFI UDP Protocol,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp-protocol
-30.1.1,UDP4 Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#udp4-service-binding-protocol
-30.1.1.1,EFI_UDP4_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-service-binding-protocol
-30.1.2,UDP4 Protocol,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#udp4-protocol
-30.1.2.1,EFI_UDP4_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol
-30.1.2.2,EFI_UDP4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-getmodedata
-30.1.2.3,EFI_UDP4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-configure
-30.1.2.4,EFI_UDP4_PROTOCOL.Groups(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-groups
-30.1.2.5,EFI_UDP4_PROTOCOL.Routes(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-routes
-30.1.2.6,EFI_UDP4_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-transmit
-30.1.2.7,EFI_UDP4_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-receive
-30.1.2.8,EFI_UDP4_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-cancel
-30.1.2.9,EFI_UDP4_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-poll
-30.2,EFI UDPv6 Protocol,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udpv6-protocol
-30.2.1,UDP6 Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#udp6-service-binding-protocol
-30.2.1.1,EFI_UDP6_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-service-binding-protocol
-30.2.2,EFI UDP6 Protocol,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol
-30.2.2.1,EFI_UDP6_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#id18
-30.2.2.2,EFI_UDP6_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-getmodedata
-30.2.2.3,EFI_UDP6_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-configure
-30.2.2.4,EFI_UDP6_PROTOCOL.Groups(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-groups
-30.2.2.5,EFI_UDP6_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-transmit
-30.2.2.6,EFI_UDP6_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-receive
-30.2.2.7,EFI_UDP6_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-cancel
-30.2.2.8,EFI_UDP6_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-poll
-30.3,EFI MTFTPv4 Protocol,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftpv4-protocol
-30.3.1,EFI_MTFTP4_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-service-binding-protocol
-30.3.2,EFI_MTFTP4_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol
-30.3.3,EFI_MTFTP4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-getmodedata
-30.3.4,EFI_MTFTP4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-configure
-30.3.5,EFI_MTFTP4_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-getinfo
-30.3.6,EFI_MTFTP4_PROTOCOL.ParseOptions(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-parseoptions
-30.3.7,EFI_MTFTP4_PROTOCOL.ReadFile(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-readfile
-30.3.8,EFI_MTFTP4_PROTOCOL.WriteFile(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-writefile
-30.3.9,EFI_MTFTP4_PROTOCOL.ReadDirectory(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-readdirectory
-30.3.10,EFI_MTFTP4_PROTOCOL.POLL(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-poll
-30.4,EFI MTFTPv6 Protocol,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftpv6-protocol
-30.4.1,MTFTP6 Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#mtftp6-service-binding-protocol
-30.4.1.1,EFI_MTFTP6_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-service-binding-protocol
-30.4.2,MTFTP6 Protocol,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#mtftp6-protocol
-30.4.2.1,EFI_MTFTP6_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol
-30.4.2.2,EFI_MTFTP6_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-getmodedata
-30.4.2.3,EFI_MTFTP6_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-configure
-30.4.2.4,EFI_MTFTP6_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-getinfo
-30.4.2.5,EFI_MTFTP6_PROTOCOL.ParseOptions(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-parseoptions
-30.4.2.6,EFI_MTFTP6_PROTOCOL.ReadFile(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-readfile
-30.4.2.7,EFI_MTFTP6_PROTOCOL.WriteFile(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-writefile
-30.4.2.8,EFI_MTFTP6_PROTOCOL.ReadDirectory(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-readdirectory
-30.4.2.9,EFI_MTFTP6_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.10_A/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-poll
-31,EFI Redfish Service Support,https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html
-31.1,EFI Redfish Discover Protocol,https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-protocol
-31.1.1,Overview,https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#overview
-31.1.2,EFI Redfish Discover Driver,https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-driver
-31.1.3,EFI Redfish Discover Client,https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-client
-31.1.4,EFI Redfish Discover Protocol,https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-protocol-1
-31.1.4.1,EFI_REDFISH_DISCOVER_PROTOCOL.GetNetworkInterfaceList(),https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-protocol-getnetworkinterfacelist
-31.1.4.2,EFI_REDFISH_DISCOVER_PROTOCOL.AcquireRedfishService(),https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-protocol-acquireredfishservice
-31.1.4.3,EFI_REDFISH_DISCOVER_PROTOCOL.AbortAcquireRedfishService(),https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-protocol-abortacquireredfishservice
-31.1.4.4,EFI_REDFISH_DISCOVER_PROTOCOL.ReleaseRedfishService(),https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-protocol-releaseredfishservice
-31.1.5,Implementation Examples,https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#implementation-examples
-31.1.5.1,Processes to Discover Redfish Services,https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#processes-to-discover-redfish-services
-31.1.5.2,Network Interface Configuration,https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#network-interface-configuration
-31.2,EFI Redfish JSON Structure Converter,https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#efi-redfish-json-structure-converter
-31.2.1,The Guidance of Writing EFI Redfish JSONStructure Converter,https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#the-guidance-of-writing-efi-redfish-jsonstructure-converter
-31.2.2,The Guidance of Using EFI Redfish JSON Structure Converter,https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#the-guidance-of-using-efi-redfish-json-structure-converter
-32,Secure Boot and Driver Signing,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html
-32.1,Secure Boot,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#secure-boot
-32.1.1,EFI_AUTHENTICATION_INFO_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#efi-authentication-info-protocol
-32.1.2,EFI_AUTHENTICATION_INFO_PROTOCOL.Get(),https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#efi-authentication-info-protocol-get
-32.1.3,EFI_AUTHENTICATION_INFO_PROTOCOL.Set(),https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#efi-authentication-info-protocol-set
-32.1.4,Authentication Nodes,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#authentication-nodes
-32.1.5,Generic Authentication Node Structures,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#generic-authentication-node-structures
-32.1.6,CHAP (using RADIUS) Authentication Node,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#chap-using-radius-authentication-node
-32.2,UEFI Driver Signing Overview,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#uefi-driver-signing-overview
-32.2.1,Digital Signatures,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#digital-signatures
-32.2.2,Embedded Signatures,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#embedded-signatures
-32.2.3,Creating Image Digests from Images,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#creating-image-digests-from-images
-32.2.4,Code Definitions,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#code-definitions
-32.2.4.1,WIN_CERTIFICATE,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#win-certificate
-32.2.4.2,WIN_CERTIFICATE_EFI_PKCS1_15,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#win-certificate-efi-pkcs1-15
-32.2.4.3,WIN_CERTIFICATE_UEFI_GUID,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#win-certificate-uefi-guid
-32.3,Firmware/OS Key Exchange: Creating Trust Relationships,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#firmware-os-key-exchange-creating-trust-relationships
-32.3.1,Enrolling The Platform Key,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#enrolling-the-platform-key
-32.3.2,Clearing The Platform Key,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#clearing-the-platform-key
-32.3.3,Transitioning to Audit Mode,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#transitioning-to-audit-mode
-32.3.4,Transitioning to Deployed Mode,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#transitioning-to-deployed-mode
-32.3.5,Enrolling Key Exchange Keys,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#enrolling-key-exchange-keys
-32.3.6,Platform Firmware Key Storage Requirements,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#platform-firmware-key-storage-requirements
-32.4,Firmware/OS Key Exchange: Passing Public Keys,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#firmware-os-key-exchange-passing-public-keys
-32.4.1,Signature Database,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#signature-database
-32.4.1.1,EFI_SIGNATURE_DATA,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#efi-signature-data
-32.4.2,Image Execution Information Table,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#image-execution-information-table
-32.5,Firmware/OS Crypto Algorithm Exchange,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#firmware-os-crypto-algorithm-exchange
-32.6,UEFI Image Validation,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#uefi-image-validation
-32.6.1,Overview,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#overview
-32.6.2,Authorized User,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#authorized-user
-32.6.3,Signature Database Update,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#signature-database-update
-32.6.3.1,Using The Image Execution Information Table,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#using-the-image-execution-information-table
-32.6.3.2,Firmware Policy,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#firmware-policy
-32.6.3.3,Authorization Process,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#authorization-process
-32.7,Device Authentication,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#device-authentication
-32.7.1,Overview,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#device-authentication-overview
-32.7.2,Authorized User,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#device-authentication-authorized-user
-32.7.3,Device Signature Database Update,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#device-signature-database-update
-32.8,Code Definitions,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#secure-boot-and-driver-signing-code-definitions
-32.8.1,UEFI Image Variable GUID & Variable Name,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#uefi-image-variable-guid-variable-name
-32.8.2,UEFI Device Signature Variable GUID and Variable Name,https://uefi.org/specs/UEFI/2.10_A/32_Secure_Boot_and_Driver_Signing.html#uefi-device-signature-variable-guid-and-variable-name
-33,Human Interface Infrastructure Overview,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html
-33.1,Goals,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#goals
-33.2,Design Discussion,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#design-discussion
-33.2.1,Drivers And Applications,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#drivers-and-applications
-33.2.1.1,Platform and Driver Configuration,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#platform-and-driver-configuration
-33.2.1.2,Pre-O/S applications,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#pre-o-s-applications
-33.2.1.3,Description of User Interface Components,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#description-of-user-interface-components
-33.2.1.4,Forms,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#forms
-33.2.1.5,Strings,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#strings
-33.2.1.6,Images/Fonts,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#images-fonts
-33.2.1.7,Consumers of the user interface data,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#consumers-of-the-user-interface-data
-33.2.1.8,Connected forms browser/processor,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#connected-forms-browser-processor
-33.2.1.9,Disconnected Forms Browser/Processor,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#disconnected-forms-browser-processor
-33.2.1.10,O/S-Present Forms Browser/Processor,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#o-s-present-forms-browser-processor
-33.2.1.11,Where are the Results Stored,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#where-are-the-results-stored
-33.2.2,Localization,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#localization
-33.2.3,User Input,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#user-input
-33.2.4,Keyboard Layout,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#keyboard-layout
-33.2.4.1,Keyboard Mapping,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#keyboard-mapping
-33.2.4.2,Modifier Keys,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#modifier-keys
-33.2.4.3,Non-Spacing Keys,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#non-spacing-keys
-33.2.5,Forms,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#forms-1
-33.2.5.1,Form Sets,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#form-sets
-33.2.5.2,Forms,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#forms-2
-33.2.5.3,Statements,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#statements
-33.2.5.4,Questions,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#questions
-33.2.5.5,Options,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#options
-33.2.5.6,Storage,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#storage
-33.2.5.7,Expressions,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#expressions
-33.2.5.8,Defaults,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#defaults
-33.2.5.9,Validation,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#validation
-33.2.5.10,Forms Processing,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#forms-processing
-33.2.5.11,Forms Editing,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#forms-editing
-33.2.5.12,Forms Processing & Security Privileges,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#forms-processing-security-privileges
-33.2.6,Strings,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#strings-1
-33.2.6.1,Configuration Language Paradigm,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#configuration-language-paradigm
-33.2.6.2,Unicode Usage,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#unicode-usage
-33.2.7,Fonts,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#fonts
-33.2.7.1,Font Attributes,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#font-attributes
-33.2.7.2,Limiting Glyphs,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#limiting-glyphs
-33.2.7.3,Fixed Font Description,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#fixed-font-description
-33.2.7.4,Proportional Fonts Description,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#proportional-fonts-description
-33.2.8,Images,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#images
-33.2.8.1,Converting to a 32-bit Display,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#converting-to-a-32-bit-display
-33.2.8.2,Non-TrueColor Displays,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#non-truecolor-displays
-33.2.9,HII Database,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#hii-database
-33.2.10,Forms Browser,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#forms-browser
-33.2.10.1,User Interaction,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#user-interaction
-33.2.11,Configuration Settings,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#configuration-settings
-33.2.11.1,OS Runtime Utilization,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#os-runtime-utilization
-33.2.11.2,Working with a UEFI Configuration Language,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#working-with-a-uefi-configuration-language
-33.2.12,Form Callback Logic,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#form-callback-logic
-33.2.13,Driver Model Interaction,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#driver-model-interaction
-33.2.14,Human Interface Component Interactions,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#human-interface-component-interactions
-33.2.15,Standards Map Forms,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#standards-map-forms
-33.2.15.1,Create A Question-s Value By Combing MultipleConfiguration Settings,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#create-a-questions-value-by-combing-multipleconfiguration-settings
-33.2.15.2,Changing Multiple Configuration Settings FromOne Question-s Value,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#changing-multiple-configuration-settings-fromone-questions-value
-33.2.15.3,Value Shifting,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#value-shifting
-33.2.15.4,Prompts,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#prompts
-33.3,Code Definitions,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#code-definitions
-33.3.1,Package Lists and Package Headers,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#package-lists-and-package-headers
-33.3.1.1,EFI_HII_PACKAGE_HEADER,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#efi-hii-package-header
-33.3.1.2,EFI_HII_PACKAGE_LIST_HEADER,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#efi-hii-package-list-header
-33.3.2,Simplified Font Package,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#simplified-font-package
-33.3.2.1,EFI_HII_SIMPLE_FONT_PACKAGE_HDR,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#efi-hii-simple-font-package-hdr
-33.3.2.2,EFI_NARROW_GLYPH,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#efi-narrow-glyph
-33.3.2.3,EFI_WIDE_GLYPH,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#efi-wide-glyph
-33.3.3,Font Package,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#font-package
-33.3.3.1,Fixed Header,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#fixed-header
-33.3.3.2,Glyph Information,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#glyph-information
-33.3.4,Device Path Package,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#device-path-package
-33.3.5,GUID Package,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#guid-package
-33.3.6,String Package,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#string-package
-33.3.6.1,Fixed Header,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#fixed-header-1
-33.3.6.2,String Information,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#string-information
-33.3.6.3,String Encoding,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#string-encoding
-33.3.7,Image Package,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#image-package
-33.3.7.1,Fixed Header,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#fixed-header-2
-33.3.7.2,Image Information,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#image-information
-33.3.7.3,Palette Information,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#palette-information
-33.3.8,Forms Package,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#forms-package
-33.3.8.1,Binary Encoding,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#binary-encoding
-33.3.8.2,Standard Headers,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#standard-headers
-33.3.8.3,Opcode Reference,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#opcode-reference
-33.3.9,Keyboard Package,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#keyboard-package
-33.3.10,Animations Package,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#animations-package
-33.3.10.1,Animated Images Package,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#animated-images-package
-33.3.10.2,Animation Information,https://uefi.org/specs/UEFI/2.10_A/33_Human_Interface_Infrastructure.html#animation-information
-34,HII Protocols,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html
-34.1,Font Protocol,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#font-protocol
-34.1.1,EFI_HII_FONT_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-protocol
-34.1.2,EFI_HII_FONT_PROTOCOL.StringToImage(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-protocol-stringtoimage
-34.1.3,EFI_HII_FONT_PROTOCOL.StringIdToImage(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-protocol-stringidtoimage
-34.1.4,EFI_HII_FONT_PROTOCOL.GetGlyph(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-protocol-getglyph
-34.1.5,EFI_HII_FONT_PROTOCOL.GetFontInfo(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-protocol-getfontinfo
-34.2,EFI HII Font Ex Protocol,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-ex-protocol
-34.2.1,EFI_HII_FONT_EX_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-ex-protocol-1
-34.2.2,EFI_HII_FONT_EX_PROTOCOL.StringToImageEx(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-ex-protocol-stringtoimageex
-34.2.3,EFI_HII_FONT_EX_PROTOCOL.StringIdToImageEx(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-ex-protocol-stringidtoimageex
-34.2.4,EFI_HII_FONT_EX_PROTOCOL.GetGlyphEx(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-ex-protocol-getglyphex
-34.2.5,EFI_HII_FONT_EX_PROTOCOL.GetFontInfoEx(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-ex-protocol-getfontinfoex
-34.2.6,EFI_HII_FONT_EX_PROTOCOL.GetGlyphInfo(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-ex-protocol-getglyphinfo
-34.2.7,Code Definitions,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#code-definitions
-34.2.7.1,EFI_FONT_DISPLAY_INFO,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-font-display-info
-34.2.7.2,EFI_IMAGE_OUTPUT,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-image-output
-34.3,String Protocol,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#string-protocol
-34.3.1,EFI_HII_STRING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-string-protocol
-34.3.2,EFI_HII_STRING_PROTOCOL.NewString(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-string-protocol-newstring
-34.3.3,EFI_HII_STRING_PROTOCOL.GetString(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-string-protocol-getstring
-34.3.4,EFI_HII_STRING_PROTOCOL.SetString(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-string-protocol-setstring
-34.3.5,EFI_HII_STRING_PROTOCOL.GetLanguages(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-string-protocol-getlanguages
-34.3.6,EFI_HII_STRING_PROTOCOL.GetSecondaryLanguages(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-string-protocol-getsecondarylanguages
-34.4,Image Protocol,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#image-protocol
-34.4.1,EFI_HII_IMAGE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-protocol
-34.4.2,EFI_HII_IMAGE_PROTOCOL.NewImage(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-protocol-newimage
-34.4.3,EFI_HII_IMAGE_PROTOCOL.GetImage(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-protocol-getimage
-34.4.4,EFI_HII_IMAGE_PROTOCOL.SetImage(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-protocol-setimage
-34.4.5,EFI_HII_IMAGE_PROTOCOL.DrawImage(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-protocol-drawimage
-34.4.6,EFI_HII_IMAGE_PROTOCOL.DrawImageId(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-protocol-drawimageid
-34.5,EFI HII Image Ex Protocol,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-ex-protocol
-34.5.1,EFI_HII_IMAGE_EX_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-ex-protoco-1
-34.5.2,EFI_HII_IMAGE_EX_PROTOCOL.NewImageEx(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-ex-protocol-newimageex
-34.5.3,EFI_HII_IMAGE_EX_PROTOCOL.GetImageEx(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-ex-protocol-getimageex
-34.5.4,EFI_HII_IMAGE_EX_PROTOCOL.SetImageEx(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-ex-protocol-setimageex
-34.5.5,EFI_HII_IMAGE_EX_PROTOCOL.DrawImageEx(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-ex-protocol-drawimageex
-34.5.6,EFI_HII_IMAGE_EX_PROTOCOL.DrawImageIdEx(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-ex-protocol-drawimageidex
-34.5.7,EFI_HII_IMAGE_EX_PROTOCOL.GetImageInfo(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-ex-protocol-getimageinfo
-34.6,EFI HII Image Decoder Protocol,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-decoder-protocol
-34.6.1,EFI_HII_IMAGE_DECODER_PROTOCOL.DecodeImage(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-decoder-protocol-decodeimage
-34.6.2,EFI_HII_IMAGE_DECODER_PROTOCOL.GetImageDecoderName(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-decoder-protocol-getimagedecodername
-34.6.3,EFI_HII_IMAGE_DECODER_PROTOCOL.GetImageInfo(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-decoder-protocol-getimageinfo
-34.6.4,EFI_HII_IMAGE_DECODER_PROTOCOL.Decode(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-image-decoder-protocol-decode
-34.7,Font Glyph Generator Protocol,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#font-glyph-generator-protocol
-34.7.1,EFI_HII_FONT_GLYPH_GENERATOR_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-glyph-generator-protocol
-34.7.2,EFI_HII_FONT_GLYPH_GENERATOR_PROTOCOL.GenerateGlyph(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-glyph-generator-protocol-generateglyph
-34.7.3,EFI_HII_FONT_GLYPH_GENERATOR_PROTOCOL.GenerateGlyphImage(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-font-glyph-generator-protocol-generateglyphimage
-34.8,Database Protocol,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#database-protocol
-34.8.1,EFI_HII_DATABASE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-protocol
-34.8.2,EFI_HII_DATABASE_PROTOCOL.NewPackageList(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-protocol-newpackagelist
-34.8.3,EFI_HII_DATABASE_PROTOCOL.RemovePackageList(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-protocol-removepackagelist
-34.8.4,EFI_HII_DATABASE_PROTOCOL.UpdatePackageList(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-protocol-updatepackagelist
-34.8.5,EFI_HII_DATABASE_PROTOCOL.ListPackageLists(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-protocol-listpackagelists
-34.8.6,EFI_HII_DATABASE_PROTOCOL.ExportPackageLists(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-protocol-exportpackagelists
-34.8.7,EFI_HII_DATABASE_PROTOCOL.RegisterPackageNotify(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-protocol-registerpackagenotify
-34.8.8,EFI_HII_DATABASE_PROTOCOL.UnregisterPackageNotify(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-protocol-unregisterpackagenotify
-34.8.9,EFI_HII_DATABASE_PROTOCOL.FindKeyboardLayouts(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-protocol-findkeyboardlayouts
-34.8.10,EFI_HII_DATABASE_PROTOCOL.GetKeyboardLayout(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-protocol-getkeyboardlayout
-34.8.11,EFI_HII_DATABASE_PROTOCOL.SetKeyboardLayout(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-protocol-setkeyboardlayout
-34.8.12,EFI_HII_DATABASE_PROTOCOL.GetPackageListHandle(),https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-protocol-getpackagelisthandle
-34.8.13,Database Structures,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#database-structures
-34.8.13.1,EFI_HII_DATABASE_NOTIFY,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-notify
-34.8.14,EFI_HII_DATABASE_NOTIFY_TYPE,https://uefi.org/specs/UEFI/2.10_A/34_HII_Protocols.html#efi-hii-database-notify-type
-35,HII Configuration Processing and Browser Protocol,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html
-35.1,Introduction,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#introduction
-35.1.1,Common Configuration Data Format,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#common-configuration-data-format
-35.1.2,Data Flow,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#data-flow
-35.2,Configuration Strings,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#configuration-strings
-35.2.1,String Syntax,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#string-syntax
-35.2.1.1,Basic forms,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#basic-forms
-35.2.1.2,Types,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#types
-35.2.1.3,Routing elements,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#routing-elements
-35.2.1.4,Body elements,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#body-elements
-35.2.1.5,Configuration strings,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#configuration-strings-1
-35.2.1.6,Keyword strings,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#keyword-strings
-35.2.2,String Types,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#string-types
-35.3,EFI Configuration Keyword Handler Protocol,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-configuration-keyword-handler-protocol
-35.3.1,EFI_CONFIG_KEYWORD_HANDLER_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-config-keyword-handler-protocol
-35.3.2,EFI_KEYWORD_HANDLER _PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-keyword-handler-protocol-setdata
-35.3.3,EFI_KEYWORD_HANDLER _PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-keyword-handler-protocol-getdata
-35.4,EFI HII Configuration Routing Protocol,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-configuration-routing-protocol
-35.4.1,EFI_HII_CONFIG_ROUTING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol
-35.4.2,EFI_HII_CONFIG_ROUTING_PROTOCOL.ExtractConfig(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol-extractconfig
-35.4.3,EFI_HII_CONFIG_ROUTING_PROTOCOL.ExportConfig(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol-exportconfig
-35.4.4,EFI_HII_CONFIG_ROUTING_PROTOCOL.RouteConfig(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol-routeconfig
-35.4.5,EFI_HII_CONFIG_ROUTING_PROTOCOL.BlockToConfig(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol-blocktoconfig
-35.4.6,EFI_HII_CONFIG_ROUTING_PROTOCOL.ConfigToBlock(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol-configtoblock
-35.4.7,EFI_HII_CONFIG_ROUTING_PROTOCOL.GetAltCfg(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol-getaltcfg
-35.5,EFI HII Configuration Access Protocol,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-configuration-access-protocol
-35.5.1,EFI_HII_CONFIG_ACCESS_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-access-protocol
-35.5.2,EFI_HII_CONFIG_ACCESS_PROTOCOL.ExtractConfig(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-access-protocol-extractconfig
-35.5.3,EFI_HII_CONFIG_ACCESS_PROTOCOL.RouteConfig(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-access-protocol-routeconfig
-35.5.4,EFI_HII_CONFIG_ACCESS_PROTOCOL.CallBack(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-access-protocol-callback
-35.6,Form Browser Protocol,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#form-browser-protocol
-35.6.1,EFI_FORM_BROWSER2_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-form-browser2-protocol
-35.6.2,EFI_FORM_BROWSER2_PROTOCOL.SendForm(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-form-browser2-protocol-sendform
-35.6.3,EFI_FORM_BROWSER2_PROTOCOL.BrowserCallback(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-form-browser2-protocol-browsercallback
-35.7,HII Popup Protocol,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#hii-popup-protocol
-35.7.1,EFI_HII_POPUP_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-popup-protocol
-35.7.2,EFI_HII_POPUP_PROTOCOL.CreatePopup(),https://uefi.org/specs/UEFI/2.10_A/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-popup-protocol-createpopup
-36,User Identification,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html
-36.1,User Identification Overview,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#user-identification-overview
-36.1.1,User Identify,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#user-identify
-36.1.2,User Profiles,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#user-profiles
-36.1.2.1,User Profile Database,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#user-profile-database
-36.1.2.2,User Identification Policy,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#user-identification-policy
-36.1.3,Credential Providers,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#credential-providers
-36.1.4,Security Considerations,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#security-considerations
-36.1.5,Deferred Execution,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#deferred-execution
-36.2,User Identification Process,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#user-identification-process
-36.2.1,User Identification Process,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#user-identification-process-1
-36.2.2,Changing The Current User Profile,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#changing-the-current-user-profile
-36.2.3,Ready To Boot,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#ready-to-boot
-36.3,Code Definitions,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#code-definitions
-36.3.1,User Manager Protocol,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#user-manager-protocol
-36.3.1.1,EFI_USER_MANAGER_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-manager-protocol
-36.3.1.2,EFI_USER_MANAGER_PROTOCOL.Create(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-manager-protocol-create
-36.3.1.3,EFI_USER_MANAGER_PROTOCOL.Delete(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-manager-protocol-delete
-36.3.1.4,EFI_USER_MANAGER_PROTOCOL.GetNext(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-manager-protocol-getnext
-36.3.1.5,EFI_USER_MANAGER_PROTOCOL.Current(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-manager-protocol-current
-36.3.1.6,EFI_USER_MANAGER_PROTOCOL.Identify(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-manager-protocol-identify
-36.3.1.7,EFI_USER_MANAGER_PROTOCOL.Find(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-manager-protocol-find
-36.3.1.8,EFI_USER_MANAGER_PROTOCOL.Notify(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-manager-protocol-notify
-36.3.1.9,EFI_USER_MANAGER_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-manager-protocol-getinfo
-36.3.1.10,EFI_USER_MANAGER_PROTOCOL.SetInfo(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-manager-protocol-setinfo
-36.3.1.11,EFI_USER_MANAGER_PROTOCOL.DeleteInfo(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-manager-protocol-deleteinfo
-36.3.1.12,EFI_USER_MANAGER_PROTOCOL.GetNextInfo(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-manager-protocol-getnextinfo
-36.3.2,Credential Provider Protocols,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#credential-provider-protocols
-36.3.2.1,EFI_USER_CREDENTIAL2_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-credential2-protocol
-36.3.2.2,EFI_USER_CREDENTIAL2_PROTOCOL.Enroll(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-credential2-protocol-enroll
-36.3.2.3,EFI_USER_CREDENTIAL2_PROTOCOL.Form(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-credential2-protocol-form
-36.3.2.4,EFI_USER_CREDENTIAL2_PROTOCOL.Tile(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-credential2-protocol-tile
-36.3.2.5,EFI_USER_CREDENTIAL2_PROTOCOL.Title(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-credential2-protocol-title
-36.3.2.6,EFI_USER_CREDENTIAL2_PROTOCOL.User(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-credential2-protocol-user
-36.3.2.7,EFI_USER_CREDENTIAL2_PROTOCOL.Select(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-credential2-protocol-select
-36.3.2.8,EFI_USER_CREDENTIAL2_PROTOCOL.Deselect(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-credential2-protocol-deselect
-36.3.2.9,EFI_USER_CREDENTIAL2_PROTOCOL.Default(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-credential2-protocol-default
-36.3.2.10,EFI_USER_CREDENTIAL2_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-credential2-protocol-getinfo
-36.3.2.11,EFI_USER_CREDENTIAL2_PROTOCOL.GetNextInfo(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-credential2-protocol-getnextinfo
-36.3.2.12,EFI_USER_CREDENTIAL2_PROTOCOL.Delete(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-credential2-protocol-delete
-36.3.3,Deferred Image Load Protocol,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#deferred-image-load-protocol
-36.3.3.1,EFI_DEFERRED_IMAGE_LOAD_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-deferred-image-load-protocol
-36.3.3.2,EFI_DEFERRED_IMAGE_LOAD_PROTOCOL.GetImageInfo(),https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-deferred-image-load-protocol-getimageinfo
-36.4,User Information,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#user-information
-36.4.1,EFI_USER_INFO_ACCESS_POLICY_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-access-policy-record
-36.4.1.1,EFI_USER_INFO_ACCESS_FORBID_LOAD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-access-forbid-load
-36.4.1.2,EFI_USER_INFO_ACCESS_PERMIT_LOAD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-access-permit-load
-36.4.1.3,EFI_USER_INFO_ACCESS_ENROLL_SELF,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-access-enroll-self
-36.4.1.4,EFI_USER_INFO_ACCESS_ENROLL_OTHERS,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-access-enroll-others
-36.4.1.5,EFI_USER_INFO_ACCESS_MANAGE,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-access-manage
-36.4.1.6,EFI_USER_INFO_ACCESS_SETUP,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-access-setup
-36.4.1.7,EFI_USER_INFO_ACCESS_FORBID_CONNECT,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-access-forbid-connect
-36.4.1.8,EFI_USER_INFO_ACCESS_PERMIT_CONNECT,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-access-permit-connect
-36.4.1.9,EFI_USER_INFO_ACCESS_BOOT_ORDER,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-access-boot-order
-36.4.2,EFI_USER_INFO_CBEFF_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-cbeff-record
-36.4.3,EFI_USER_INFO_CREATE_DATE_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-create-date-record
-36.4.4,EFI_USER_INFO_CREDENTIAL_PROVIDER_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-credential-provider-record
-36.4.5,EFI_USER_INFO_CREDENTIAL_PROVIDER_NAME_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-credential-provider-name-record
-36.4.6,EFI_USER_INFO_CREDENTIAL_TYPE_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-credential-type-record
-36.4.7,EFI_USER_INFO_CREDENTIAL_TYPE_NAME_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-credential-type-name-record
-36.4.8,EFI_USER_INFO_GUID_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-guid-record
-36.4.9,EFI_USER_INFO_FAR_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-far-record
-36.4.10,EFI_USER_INFO_IDENTIFIER_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-identifier-record
-36.4.11,EFI_USER_INFO_IDENTITY_POLICY_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-identity-policy-record
-36.4.12,EFI_USER_INFO_NAME_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-name-record
-36.4.13,EFI_USER_INFO_PKCS11_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-pkcs11-record
-36.4.14,EFI_USER_INFO_RETRY_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-retry-record
-36.4.15,EFI_USER_INFO_USAGE_DATE_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-usage-date-record
-36.4.16,EFI_USER_INFO_USAGE_COUNT_RECORD,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#efi-user-info-usage-count-record
-36.5,User Information Table,https://uefi.org/specs/UEFI/2.10_A/36_User_Identification.html#user-information-table
-37,Secure Technologies,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html
-37.1,Hash Overview,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#hash-overview
-37.1.1,Hash References,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#hash-references
-37.1.1.1,EFI_HASH_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-hash-service-binding-protocol
-37.1.1.2,EFI_HASH_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-hash-protocol
-37.1.1.3,EFI_HASH_PROTOCOL.GetHashSize(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-hash-protocol-gethashsize
-37.1.1.4,EFI_HASH_PROTOCOL.Hash(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-hash-protocol-hash
-37.1.2,Other Code Definitions,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#other-code-definitions
-37.1.2.1,"EFI_SHA1_HASH, EFI_SHA224_HASH, EFI_SHA256_HASH,EFI_SHA384_HASH, EFI_SHA512HASH, EFI_MD5_HASH",https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-sha1-hash-efi-sha224-hash-efi-sha256-hash-efi-sha384-hash-efi-sha512hash-efi-md5-hash
-37.1.2.2,EFI Hash Algorithms,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-hash-algorithms
-37.2,Hash2 Protocols,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#hash2-protocols
-37.2.1,EFI Hash2 Service Binding Protocol,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-hash2-service-binding-protocol
-37.2.1.1,EFI_HASH2_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#id13
-37.2.2,EFI Hash2 Protocol,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-hash2-protocol
-37.2.2.1,EFI_HASH2_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#id15
-37.2.2.2,EFI_HASH2_PROTOCOL.GetHashSize(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-hash2-protocol-gethashsize
-37.2.2.3,EFI_HASH2_PROTOCOL.Hash(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-hash2-protocol-hash
-37.2.2.4,EFI_HASH2_PROTOCOL.HashInit(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-hash2-protocol-hashinit
-37.2.2.5,EFI_HASH2_PROTOCOL.HashUpdate(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-hash2-protocol-hashupdate
-37.2.2.6,EFI_HASH2_PROTOCOL.HashFinal(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-hash2-protocol-hashfinal
-37.2.3,Other Code Definitions,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#other-code-definitions-1
-37.2.3.1,EFI_HASH2_OUTPUT,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-hash2-output
-37.3,Key Management Service,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#key-management-service
-37.3.1,EFI_KEY_MANAGEMENT_SERVICE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-key-management-service-protocol
-37.3.2,EFI_KMS_PROTOCOL.GetServiceStatus(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-kms-protocol-getservicestatus
-37.3.2.1,EFI_KMS_PROTOCOL.RegisterClient(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-kms-protocol-registerclient
-37.3.2.2,EFI_KMS_PROTOCOL.CreateKey(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-kms-protocol-createkey
-37.3.2.3,EFI_KMS_PROTOCOL.GetKey(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-kms-protocol-getkey
-37.3.2.4,EFI_KMS_PROTOCOL.AddKey(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-kms-protocol-addkey
-37.3.2.5,EFI_KMS_PROTOCOL.DeleteKey(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-kms-protocol-deletekey
-37.3.2.6,EFI_KMS_PROTOCOL.GetKeyAttributes(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-kms-protocol-getkeyattributes
-37.3.2.7,EFI_KMS_PROTOCOL.AddKeyAttributes(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-kms-protocol-addkeyattributes
-37.3.2.8,EFI_KMS_PROTOCOL.DeleteKeyAttributes(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-kms-protocol-deletekeyattributes
-37.3.2.9,EFI_KMS_PROTOCOL.GetKeyByAttributes(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-kms-protocol-getkeybyattributes
-37.4,PKCS7 Verify Protocol,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#pkcs7-verify-protocol
-37.4.1,EFI_PKCS7_VERIFY_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-pkcs7-verify-protocol
-37.4.2,EFI_PKCS7_VERIFY_PROTOCOL.VerifyBuffer(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-pkcs7-verify-protocol-verifybuffer
-37.4.2.1,EFI_PKCS7_VERIFY_PROTOCOL.VerifySignature(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-pkcs7-verify-protocol-verifysignature
-37.5,Random Number Generator Protocol,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#random-number-generator-protocol
-37.5.1,EFI_RNG_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-rng-protocol
-37.5.2,EFI_RNG_PROTOCOL.GetInfo,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-rng-protocol-getinfo
-37.5.3,EFI_RNG_PROTOCOL.GetRNG,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-rng-protocol-getrng
-37.5.4,EFI RNG Algorithm Definitions,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-rng-algorithm-definitions
-37.5.5,RNG References,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#rng-references
-37.6,Smart Card Reader and Smart Card Edge Protocol,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#smart-card-reader-and-smart-card-edge-protocol
-37.6.1,Smart Card Reader Protocol,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#smart-card-reader-protocol
-37.6.1.1,EFI_SMART_CARD_READER_PROTOCOL Summary,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-reader-protocol-summary
-37.6.2,EFI_SMART_CARD_READER_PROTOCOL.SCardConnect(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-reader-protocol-scardconnect
-37.6.3,EFI_SMART_CARD_READER_PROTOCOL.SCardDisconnect(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-reader-protocol-scarddisconnect
-37.6.4,EFI_SMART_CARD_READER_PROTOCOL.SCardStatus(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-reader-protocol-scardstatus
-37.6.5,EFI_SMART_CARD_READER_PROTOCOL.SCardTransmit(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-reader-protocol-scardtransmit
-37.6.6,EFI_SMART_CARD_READER_PROTOCOL.SCardControl(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-reader-protocol-scardcontrol
-37.6.7,EFI_SMART_CARD_READER_PROTOCOL.SCardGetAttrib(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-reader-protocol-scardgetattrib
-37.6.8,Smart Card Edge Protocol,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#smart-card-edge-protocol
-37.6.8.1,EFI_SMART_CARD_EDGE_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-edge-protocol
-37.6.8.2,EFI_SMART_CARD_EDGE_PROTOCOL.GetContext(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-edge-protocol-getcontext
-37.6.8.3,EFI_SMART_CARD_EDGE_PROTOCOL. Connect(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-edge-protocol-connect
-37.6.8.4,EFI_SMART_CARD_EDGE_PROTOCOL.Disconnect(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-edge-protocol-disconnect
-37.6.8.5,EFI_SMART_CARD_EDGE_PROTOCOL.GetCsn,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-edge-protocol-getcsn
-37.6.8.6,EFI_SMART_CARD_EDGE_PROTOCOL.GetReaderName,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-edge-protocol-getreadername
-37.6.8.7,EFI_SMART_CARD_EDGE_PROTOCOL.VerifyPin(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-edge-protocol-verifypin
-37.6.8.8,EFI_SMART_CARD_EDGE_PROTOCOL.GetPinRemaining(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-edge-protocol-getpinremaining
-37.6.8.9,EFI_SMART_CARD_EDGE_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-edge-protocol-getdata
-37.6.8.10,EFI_SMART_CARD_EDGE_PROTOCOL.GetCredentials(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-edge-protocol-getcredentials
-37.6.8.11,EFI_SMART_CARD_EDGE_PROTOCOL.SignData(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-edge-protocol-signdata
-37.6.8.12,EFI_SMART_CARD_EDGE_PROTOCOL.DecryptData(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-edge-protocol-decryptdata
-37.6.8.13,EFI_SMART_CARD_EDGE_PROTOCOL.BuildDHAgreement(),https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-smart-card-edge-protocol-builddhagreement
-37.7,Memory Protection,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#memory-protection
-37.7.1,EFI_MEMORY_ATTRIBUTE PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-memory-attribute-protocol
-37.7.1.1,EFI_MEMORY_ATTRIBUTE_PROTOCOL.GetMemoryAttributes,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-memory-attribute-protocol-getmemoryattributes
-37.7.1.2,EFI_MEMORY_ATTRIBUTE_PROTOCOL.SetMemoryAttributes,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-memory-attribute-protocol-setmemoryattributes
-37.7.1.3,EFI_MEMORY_ATTRIBUTE_PROTOCOL.ClearMemoryAttributes,https://uefi.org/specs/UEFI/2.10_A/37_Secure_Technologies.html#efi-memory-attribute-protocol-clearmemoryattributes
-38,Confidential Computing,https://uefi.org/specs/UEFI/2.10_A/38_Confidential_Computing.html
-38.1,Virtual Platform CC Event Log,https://uefi.org/specs/UEFI/2.10_A/38_Confidential_Computing.html#virtual-platform-cc-event-log
-38.2,EFI_CC_MEASUREMENT_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/38_Confidential_Computing.html#efi-cc-measurement-protocol
-38.2.1,EFI_CC_MEASUREMENT_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/38_Confidential_Computing.html#id4
-38.2.2,EFI_CC_MEASUREMENT_PROTOCOL.GetCapability,https://uefi.org/specs/UEFI/2.10_A/38_Confidential_Computing.html#efi-cc-measurement-protocol-getcapability
-38.2.3,EFI_CC_PROTOCOL.GetEventLog,https://uefi.org/specs/UEFI/2.10_A/38_Confidential_Computing.html#efi-cc-protocol-geteventlog
-38.2.4,EFI_CC_MEASUREMENT_PROTOCOL.HashLogExtendEvent,https://uefi.org/specs/UEFI/2.10_A/38_Confidential_Computing.html#efi-cc-measurement-protocol-hashlogextendevent
-38.2.5,EFI_CC_MEASUREMENT_PROTOCOL.MapPcrToMrIndex,https://uefi.org/specs/UEFI/2.10_A/38_Confidential_Computing.html#efi-cc-measurement-protocol-mappcrtomrindex
-38.3,EFI CC Final Events Table,https://uefi.org/specs/UEFI/2.10_A/38_Confidential_Computing.html#efi-cc-final-events-table
-38.4,Vendor Specific Information,https://uefi.org/specs/UEFI/2.10_A/38_Confidential_Computing.html#vendor-specific-information
-38.4.1,Intel Trust Domain Extension,https://uefi.org/specs/UEFI/2.10_A/38_Confidential_Computing.html#intel-trust-domain-extension
-39,Miscellaneous Protocols,https://uefi.org/specs/UEFI/2.10_A/39_Micellaneous_Protocols.html
-39.1,EFI Timestamp Protocol,https://uefi.org/specs/UEFI/2.10_A/39_Micellaneous_Protocols.html#efi-timestamp-protocol
-39.1.1,EFI_TIMESTAMP_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/39_Micellaneous_Protocols.html#efi-timestampprotocol-micellaneous-protocols
-39.1.2,EFI_TIMESTAMP_PROTOCOL.GetTimestamp(),https://uefi.org/specs/UEFI/2.10_A/39_Micellaneous_Protocols.html#efi-timestamp-protocol-gettimestamp
-39.1.3,EFI_TIMESTAMP_PROTOCOL.GetProperties(),https://uefi.org/specs/UEFI/2.10_A/39_Micellaneous_Protocols.html#efi-timestamp-protocol-getproperties
-39.2,Reset Notification Protocol,https://uefi.org/specs/UEFI/2.10_A/39_Micellaneous_Protocols.html#reset-notification-protocol
-39.2.1,EFI_RESET_NOTIFICATION_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/39_Micellaneous_Protocols.html#efi-reset-notification-protocol
-39.2.2,EFI_RESET_NOTIFICATION_PROTOCOL.RegisterResetNotify(),https://uefi.org/specs/UEFI/2.10_A/39_Micellaneous_Protocols.html#efi-reset-notification-protocol-registerresetnotify
-39.2.3,EFI_RESET_NOTIFICATION_PROTOCOL.UnregisterResetNotify(),https://uefi.org/specs/UEFI/2.10_A/39_Micellaneous_Protocols.html#efi-reset-notification-protocol-unregisterresetnotify
-B.1,EFI_SIMPLE_TEXT_INPUT_PROTOCOL and EFI_SIMPLE_TEXT _INPUT_EX_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/Apx_B_Console.html#efi-simple-text-input-protocol-and-efi-simple-text-input-ex-protocol
-B.2,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL for PC ANSI or ANSI X3.64 terminals,https://uefi.org/specs/UEFI/2.10_A/Apx_B_Console.html#efi-simple-text-output-protocol-for-pc-ansi-or-ansi-x3-64-terminals
-C.1,Example Computer System,https://uefi.org/specs/UEFI/2.10_A/Apx_C_Device_Path_Examples.html#example-computer-system
-C.2,Legacy Floppy,https://uefi.org/specs/UEFI/2.10_A/Apx_C_Device_Path_Examples.html#legacy-floppy
-C.3,IDE Disk,https://uefi.org/specs/UEFI/2.10_A/Apx_C_Device_Path_Examples.html#ide-disk
-C.4,Secondary Root PCI Bus with PCI to PCI Bridge,https://uefi.org/specs/UEFI/2.10_A/Apx_C_Device_Path_Examples.html#secondary-root-pci-bus-with-pci-to-pci-bridge
-C.5,ACPI Terms,https://uefi.org/specs/UEFI/2.10_A/Apx_C_Device_Path_Examples.html#acpi-terms
-C.6,EFI Device Path as a Name Space,https://uefi.org/specs/UEFI/2.10_A/Apx_C_Device_Path_Examples.html#efi-device-path-as-a-name-space
-E.1,Introduction,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#introduction
-E.1.1,Definitions,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#definitions
-E.1.2,Referenced Specifications,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#referenced-specifications
-E.1.3,OS Network Stacks,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#os-network-stacks
-E.2,Overview,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#overview
-E.2.1,32/64-bit UNDI Interface,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#bit-undi-interface
-E.2.1.1,Issuing UNDI Commands,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-undi-commands
-E.2.2,UNDI Command Format,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#undi-command-format
-E.3,UNDI C Definitions,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#undi-c-definitions
-E.3.1,Portability Macros,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#portability-macros
-E.3.1.1,PXE_INTEL_ORDER or PXE_NETWORK_ORDER,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-intel-order-or-pxe-network-order
-E.3.1.2,PXE_UINT64_SUPPORT or PXE_NO_UINT64_SUPPORT,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-uint64-support-or-pxe-no-uint64-support
-E.3.1.3,PXE_BUSTYPE,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-bustype
-E.3.1.4,PXE_SWAP_UINT16,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-swap-uint16
-E.3.1.5,PXE_SWAP_UINT32,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-swap-uint32
-E.3.1.6,PXE_SWAP_UINT64,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-swap-uint64
-E.3.2,Miscellaneous Macros,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#miscellaneous-macros
-E.3.2.1,Miscellaneous,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#miscellaneous
-E.3.3,Portability Types,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#portability-types
-E.3.3.1,PXE_CONST,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-const
-E.3.3.2,PXE_VOLATILE,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-volatile
-E.3.3.3,PXE_VOID,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-void
-E.3.3.4,PXE_UINT8,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-uint8
-E.3.3.5,PXE_UINT16,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-uint16
-E.3.3.6,PXE_UINT32,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-uint32
-E.3.3.7,PXE_UINT64,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-uint64
-E.3.3.8,PXE_UINTN,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-uintn
-E.3.4,Simple Types,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#simple-types
-E.3.4.1,PXE_BOOL,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-bool
-E.3.4.2,PXE_OPCODE,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-opcode
-E.3.4.3,PXE_OPFLAGS,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-opflags
-E.3.4.4,PXE_STATFLAGS,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-statflags
-E.3.4.5,PXE_STATCODE,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-statcode
-E.3.4.6,PXE_IFNUM,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-ifnum
-E.3.4.7,PXE_CONTROL,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-control
-E.3.4.8,PXE_FRAME_TYPE,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-frame-type
-E.3.4.9,PXE_IPV4,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-ipv4
-E.3.4.10,PXE_IPV6,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-ipv6
-E.3.4.11,PXE_MAC_ADDR,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-mac-addr
-E.3.4.12,PXE_IFTYPE,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-iftype
-E.3.4.13,PXE_MEDIA_PROTOCOL,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-media-protocol
-E.3.5,Compound Types,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#compound-types
-E.3.5.1,PXE_HW_UNDI,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-hw-undi
-E.3.5.2,PXE_SW_UNDI,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-sw-undi
-E.3.5.3,PXE_UNDI,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-undi
-E.3.5.4,PXE_CDB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-cdb
-E.3.5.5,PXE_IP_ADDR,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-ip-addr
-E.3.5.6,PXE_DEVICE,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-device
-E.4,UNDI Commands,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#undi-commands
-E.4.1,Command Linking and Queuing,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#command-linking-and-queuing
-E.4.2,Get State,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#get-state
-E.4.2.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command
-E.4.2.2,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute
-E.4.2.3,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results
-E.4.3,Start,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#start
-E.4.3.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-1
-E.4.3.2,Preparing the CPB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb
-E.4.3.3,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-1
-E.4.3.4,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-1
-E.4.4,Stop,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#stop
-E.4.4.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-2
-E.4.4.2,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-2
-E.4.4.3,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-2
-E.4.5,Get Init Info,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#get-init-info
-E.4.5.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-3
-E.4.5.2,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-3
-E.4.5.3,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-3
-E.4.5.4,StatFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#statflags
-E.4.5.5,DB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#db
-E.4.6,Get Config Info,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#get-config-info
-E.4.6.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-4
-E.4.6.2,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-4
-E.4.6.3,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-4
-E.4.6.4,DB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#db-1
-E.4.7,Initialize,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#initialize
-E.4.7.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-5
-E.4.7.2,OpFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#opflags
-E.4.7.3,Preparing the CPB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-1
-E.4.7.4,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-5
-E.4.7.5,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-5
-E.4.7.6,StatFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#statflags-1
-E.4.7.7,Before Using the DB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#before-using-the-db
-E.4.8,Reset,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#reset
-E.4.8.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-6
-E.4.8.2,OpFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-1
-E.4.8.3,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-6
-E.4.8.4,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-6
-E.4.8.5,StatFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#statflags-2
-E.4.9,Shutdown,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#shutdown
-E.4.9.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-7
-E.4.9.2,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-7
-E.4.9.3,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-7
-E.4.10,Interrupt Enables,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#interrupt-enables
-E.4.10.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-8
-E.4.10.2,OpFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-2
-E.4.10.3,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-8
-E.4.10.4,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-8
-E.4.10.5,StatFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#statflags-3
-E.4.11,Receive Filters,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#receive-filters
-E.4.11.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-9
-E.4.11.2,OpFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-3
-E.4.11.3,Preparing the CPB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-2
-E.4.11.4,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-9
-E.4.11.5,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-9
-E.4.11.6,StatFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#statflags-4
-E.4.11.7,DB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#db-2
-E.4.12,Station Address,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#station-address
-E.4.12.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-10
-E.4.12.2,OpFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-4
-E.4.12.3,Preparing the CPB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-3
-E.4.12.4,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-10
-E.4.12.5,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-10
-E.4.12.6,Before Using the DB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#before-using-the-db-1
-E.4.13,Statistics,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#statistics
-E.4.13.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-11
-E.4.13.2,OpFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-5
-E.4.13.3,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-11
-E.4.13.4,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-11
-E.4.13.5,DB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#db-3
-E.4.14,MCast IP To MAC,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#mcast-ip-to-mac
-E.4.14.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-12
-E.4.14.2,OpFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-6
-E.4.14.3,Preparing the CPB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-4
-E.4.14.4,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-12
-E.4.14.5,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-12
-E.4.14.6,Before Using the DB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#before-using-the-db-2
-E.4.15,NvData,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#nvdata
-E.4.15.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-13
-E.4.15.2,Preparing the CPB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-5
-E.4.15.3,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-13
-E.4.15.4,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-13
-E.4.16,Get Status,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#get-status
-E.4.16.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-14
-E.4.16.2,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-14
-E.4.16.3,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-14
-E.4.16.4,StatFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#statflags-5
-E.4.16.5,Using the DB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#using-the-db
-E.4.17,Fill Header,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#fill-header
-E.4.17.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-15
-E.4.17.2,OpFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-7
-E.4.17.3,Preparing the CPB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-6
-E.4.17.4,Nonfragmented Frame,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#nonfragmented-frame
-E.4.17.5,Fragmented Frame,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#fragmented-frame
-E.4.17.6,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-15
-E.4.17.7,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-15
-E.4.18,Transmit,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#transmit
-E.4.18.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-16
-E.4.18.2,OpFlags,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-8
-E.4.18.3,Preparing the CPB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-7
-E.4.18.4,Nonfragmented Frame,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#nonfragmented-frame-1
-E.4.18.5,Fragmented Frame,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#fragmented-frame-1
-E.4.18.6,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-16
-E.4.18.7,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-16
-E.4.19,Receive,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#receive
-E.4.19.1,Issuing the Command,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-17
-E.4.19.2,Preparing the CPB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-8
-E.4.19.3,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-17
-E.4.19.4,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-17
-E.4.19.5,Using the DB,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#using-the-db-1
-E.4.20,PXE 2.1 specification wire protocol clarifications,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-2-1-specification-wire-protocol-clarifications
-E.4.20.1,Issue #1-time-outs,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issue-1-time-outs
-E.4.20.2,Issue #2 - siaddr/option 54 precedence,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issue-2-siaddr-option-54-precedence
-E.4.20.3,Issue #3 - PXE Vendor Options Existence,https://uefi.org/specs/UEFI/2.10_A/Apx_E_Universal_Network_Driver_Interfaces.html#issue-3-pxe-vendor-options-existence
-L.1,Protocol and GUID Name Changes from EFI 1.10,https://uefi.org/specs/UEFI/2.10_A/Apx_L_EFI_1.10_Protocol_Changes_and_Deprecation_List.html#protocol-and-guid-name-changes-from-efi-1-10
-M.1,Specifying individual language codes,https://uefi.org/specs/UEFI/2.10_A/Apx_M_Formats_Language_Codes_and_Language_Code_Arrays.html#specifying-individual-language-codes
-M.1.1,Specifying language code arrays:,https://uefi.org/specs/UEFI/2.10_A/Apx_M_Formats_Language_Codes_and_Language_Code_Arrays.html#specifying-language-code-arrays
-N.1,Introduction,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#introduction
-N.2,Format,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#format
-N.2.1,Record Header,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#record-header
-N.2.1.1,Notification Type,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#notification-type
-N.2.1.2,Error Status,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#error-status
-N.2.2,Section Descriptor,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#section-descriptor
-N.2.3,Non-standard Section Body,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#non-standard-section-body
-N.2.4,Processor Error Sections,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#processor-error-sections
-N.2.4.1,Generic Processor Error Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#generic-processor-error-section
-N.2.4.2,IA32/X64 Processor Error Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#ia32-x64-processor-error-section
-N.2.4.3,IA64 Processor Error Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#ia64-processor-error-section
-N.2.4.4,ARM Processor Error Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#arm-processor-error-section
-N.2.5,Memory Error Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#memory-error-section
-N.2.6,Memory Error Section 2,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#memory-error-section-2
-N.2.7,PCI Express Error Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#pci-express-error-section
-N.2.8,PCI/PCI-X Bus Error Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#pci-pci-x-bus-error-section
-N.2.9,PCI/PCI-X Component Error Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#pci-pci-x-component-error-section
-N.2.10,Firmware Error Record Reference,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#firmware-error-record-reference
-N.2.11,DMAr Error Sections,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#dmar-error-sections
-N.2.11.1,DMAr Generic Error Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#dmar-generic-error-section
-N.2.11.2,Intel- VT for Directed I/O specific DMAr Error Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#intel-vt-for-directed-i-o-specific-dmar-error-section
-N.2.11.3,IOMMU Specific DMAr Error Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#iommu-specific-dmar-error-section
-N.2.12,CCIX PER Log Error Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#ccix-per-log-error-section
-N.2.13,Compute Express Link (CXL) Protocol Error Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#compute-express-link-cxl-protocol-error-section
-N.2.14,CXL Component Events Section,https://uefi.org/specs/UEFI/2.10_A/Apx_N_Common_Platform_Error_Record.html#cxl-component-events-section
-O.1,Invocation method,https://uefi.org/specs/UEFI/2.10_A/Apx_O_UEFI_ACPI_Data_Table.html#invocation-method
-P.1,Determining space,https://uefi.org/specs/UEFI/2.10_A/Apx_P_Hardware_Error_Record_Persistence_Usage.html#determining-space
-P.2,Saving Hardware error records,https://uefi.org/specs/UEFI/2.10_A/Apx_P_Hardware_Error_Record_Persistence_Usage.html#saving-hardware-error-records
-P.3,Clearing error record variables,https://uefi.org/specs/UEFI/2.10_A/Apx_P_Hardware_Error_Record_Persistence_Usage.html#clearing-error-record-variables
-Q.1,Related Information,https://uefi.org/specs/UEFI/2.10_A/Apx_Q_References.html#related-information
-Q.2,Prerequisite Specifications,https://uefi.org/specs/UEFI/2.10_A/Apx_Q_References.html#prerequisite-specifications
-Q.2.1,ACPI Specification,https://uefi.org/specs/UEFI/2.10_A/Apx_Q_References.html#acpi-specification
-Q.2.2,Additional Considerations for Itanium-BasedPlatforms,https://uefi.org/specs/UEFI/2.10_A/Apx_Q_References.html#additional-considerations-for-itanium-basedplatforms
+1,Introduction,https://uefi.org/specs/UEFI/2.11/01_Introduction.html
+1.1,Principle of Inclusive Terminology,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#principle-of-inclusive-terminology
+1.2,UEFI Driver Model Extensions,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#uefi-driver-model-extensions
+1.3,Organization,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#organization
+1.4,Goals,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#goals
+1.5,Target Audience,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#target-audience
+1.6,UEFI Design Overview,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#uefi-design-overview
+1.7,UEFI Driver Model,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#uefi-driver-model
+1.7.1,UEFI Driver Model Goals,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#uefi-driver-model-goals
+1.7.2,Legacy Option ROM Issues,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#legacy-option-rom-issues
+1.8,Migration Requirements,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#migration-requirements
+1.8.1,Legacy Operating System Support,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#legacy-operating-system-support
+1.8.2,Supporting the UEFI Specification on a Legacy Platform,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#supporting-the-uefi-specification-on-a-legacy-platform
+1.9,Conventions Used in this Document,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#conventions-used-in-this-document
+1.9.1,Data Structure Descriptions,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#data-structure-descriptions
+1.9.2,Protocol Descriptions,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#protocol-descriptions
+1.9.3,Procedure Descriptions,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#procedure-descriptions
+1.9.4,Instruction Descriptions,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#instruction-descriptions
+1.9.5,Pseudo-Code Conventions,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#pseudo-code-conventions
+1.9.6,Typographic Conventions,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#typographic-conventions
+1.9.7,Number formats,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#number-formats
+1.9.7.1,Hexadecimal,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#hexadecimal
+1.9.7.2,Decimal,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#decimal
+1.9.8,SI & Binary prefixes,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#si-binary-prefixes
+1.9.9,Revision Numbers,https://uefi.org/specs/UEFI/2.11/01_Introduction.html#revision-numbers
+2,Overview,https://uefi.org/specs/UEFI/2.11/02_Overview.html
+2.1,Boot Manager,https://uefi.org/specs/UEFI/2.11/02_Overview.html#boot-manager
+2.1.1,UEFI Images,https://uefi.org/specs/UEFI/2.11/02_Overview.html#uefi-images
+2.1.2,UEFI Applications,https://uefi.org/specs/UEFI/2.11/02_Overview.html#uefi-applications
+2.1.3,UEFI OS Loaders,https://uefi.org/specs/UEFI/2.11/02_Overview.html#uefi-os-loaders
+2.1.4,UEFI Drivers,https://uefi.org/specs/UEFI/2.11/02_Overview.html#uefi-drivers
+2.2,Firmware Core,https://uefi.org/specs/UEFI/2.11/02_Overview.html#firmware-core
+2.2.1,UEFI Services,https://uefi.org/specs/UEFI/2.11/02_Overview.html#uefi-services
+2.2.2,Runtime Services,https://uefi.org/specs/UEFI/2.11/02_Overview.html#runtime-services
+2.3,Calling Conventions,https://uefi.org/specs/UEFI/2.11/02_Overview.html#calling-conventions
+2.3.1,Data Types,https://uefi.org/specs/UEFI/2.11/02_Overview.html#data-types
+2.3.2,IA-32 Platforms,https://uefi.org/specs/UEFI/2.11/02_Overview.html#ia-32-platforms
+2.3.2.1,Handoff State,https://uefi.org/specs/UEFI/2.11/02_Overview.html#handoff-state
+2.3.2.2,Calling Convention,https://uefi.org/specs/UEFI/2.11/02_Overview.html#calling-convention
+2.3.3,Intel-Itanium--Based Platforms,https://uefi.org/specs/UEFI/2.11/02_Overview.html#intelitanium-based-platforms
+2.3.3.1,Handoff State,https://uefi.org/specs/UEFI/2.11/02_Overview.html#handoff-state-1
+2.3.3.2,Calling Convention,https://uefi.org/specs/UEFI/2.11/02_Overview.html#calling-convention-1
+2.3.4,x64 Platforms,https://uefi.org/specs/UEFI/2.11/02_Overview.html#x64-platforms
+2.3.4.1,Handoff State,https://uefi.org/specs/UEFI/2.11/02_Overview.html#handoff-state-2
+2.3.4.2,Detailed Calling Conventions,https://uefi.org/specs/UEFI/2.11/02_Overview.html#detailed-calling-conventions
+2.3.4.3,Enabling Paging or Alternate Translations in an Application,https://uefi.org/specs/UEFI/2.11/02_Overview.html#enabling-paging-or-alternate-translations-in-an-application
+2.3.5,AArch32 Platforms,https://uefi.org/specs/UEFI/2.11/02_Overview.html#aarch32-platforms
+2.3.5.1,Handoff State,https://uefi.org/specs/UEFI/2.11/02_Overview.html#handoff-state-3
+2.3.5.2,Enabling Paging or Alternate Translations in an Application,https://uefi.org/specs/UEFI/2.11/02_Overview.html#enabling-paging-or-alternate-translations-in-an-application-1
+2.3.5.3,Detailed Calling Convention,https://uefi.org/specs/UEFI/2.11/02_Overview.html#detailed-calling-convention
+2.3.6,AArch64 Platforms,https://uefi.org/specs/UEFI/2.11/02_Overview.html#aarch64-platforms
+2.3.6.1,Memory types,https://uefi.org/specs/UEFI/2.11/02_Overview.html#memory-types
+2.3.6.2,Handoff State,https://uefi.org/specs/UEFI/2.11/02_Overview.html#handoff-state-4
+2.3.6.3,Enabling Paging or Alternate Translations in an Application,https://uefi.org/specs/UEFI/2.11/02_Overview.html#enabling-paging-or-alternate-translations-in-an-application-2
+2.3.6.4,Detailed Calling Convention,https://uefi.org/specs/UEFI/2.11/02_Overview.html#detailed-calling-convention-1
+2.3.7,RISC-V Platforms,https://uefi.org/specs/UEFI/2.11/02_Overview.html#risc-v-platforms
+2.3.7.1,Handoff State,https://uefi.org/specs/UEFI/2.11/02_Overview.html#handoff-state-5
+2.3.7.2,Enabling Paging or Alternate Translations in an Application,https://uefi.org/specs/UEFI/2.11/02_Overview.html#enabling-paging-or-alternate-translations-in-an-application-3
+2.3.7.3,Detailed Calling Convention,https://uefi.org/specs/UEFI/2.11/02_Overview.html#detailed-calling-convention-2
+2.3.8,LoongArch Platforms,https://uefi.org/specs/UEFI/2.11/02_Overview.html#loongarch-platforms
+2.3.8.1,Handoff Statue,https://uefi.org/specs/UEFI/2.11/02_Overview.html#handoff-statue
+2.3.8.2,Detailed Calling Convention,https://uefi.org/specs/UEFI/2.11/02_Overview.html#id33
+2.4,Protocols,https://uefi.org/specs/UEFI/2.11/02_Overview.html#protocols
+2.5,UEFI Driver Model,https://uefi.org/specs/UEFI/2.11/02_Overview.html#uefi-driver-model
+2.5.1,Legacy Option ROM Issues,https://uefi.org/specs/UEFI/2.11/02_Overview.html#legacy-option-rom-issues
+2.5.1.1,32-bit/16-Bit Real Mode Binaries,https://uefi.org/specs/UEFI/2.11/02_Overview.html#bit-16-bit-real-mode-binaries
+2.5.1.2,Fixed Resources for Working with Option ROMs,https://uefi.org/specs/UEFI/2.11/02_Overview.html#fixed-resources-for-working-with-option-roms
+2.5.1.3,Matching Option ROMs to their Devices,https://uefi.org/specs/UEFI/2.11/02_Overview.html#matching-option-roms-to-their-devices
+2.5.1.4,Ties to PC-AT System Design,https://uefi.org/specs/UEFI/2.11/02_Overview.html#ties-to-pc-at-system-design
+2.5.1.5,Ambiguities in Specification and WorkaroundsBorn of Experience,https://uefi.org/specs/UEFI/2.11/02_Overview.html#ambiguities-in-specification-and-workaroundsborn-of-experience
+2.5.2,Driver Initialization,https://uefi.org/specs/UEFI/2.11/02_Overview.html#driver-initialization
+2.5.3,Host Bus Controllers,https://uefi.org/specs/UEFI/2.11/02_Overview.html#host-bus-controllers
+2.5.4,Device Drivers,https://uefi.org/specs/UEFI/2.11/02_Overview.html#device-drivers
+2.5.5,Bus Drivers,https://uefi.org/specs/UEFI/2.11/02_Overview.html#bus-drivers
+2.5.6,Platform Components,https://uefi.org/specs/UEFI/2.11/02_Overview.html#platform-components
+2.5.7,Hot-Plug Events,https://uefi.org/specs/UEFI/2.11/02_Overview.html#hot-plug-events
+2.5.8,EFI Services Binding,https://uefi.org/specs/UEFI/2.11/02_Overview.html#efi-services-binding
+2.6,Requirements,https://uefi.org/specs/UEFI/2.11/02_Overview.html#requirements
+2.6.1,Required Elements,https://uefi.org/specs/UEFI/2.11/02_Overview.html#required-elements
+2.6.2,Platform-Specific Elements,https://uefi.org/specs/UEFI/2.11/02_Overview.html#platform-specific-elements
+2.6.3,Driver-Specific Elements,https://uefi.org/specs/UEFI/2.11/02_Overview.html#driver-specific-elements
+2.6.4,Extensions to this Specification Published Elsewhere,https://uefi.org/specs/UEFI/2.11/02_Overview.html#extensions-to-this-specification-published-elsewhere
+2.6.5,Cryptographic Algorithm Requirement,https://uefi.org/specs/UEFI/2.11/02_Overview.html#cryptographic-algorithm-requirement
+3,Boot Manager,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html
+3.1,Firmware Boot Manager,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#firmware-boot-manager
+3.1.1,Boot Manager Programming,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#boot-manager-programming
+3.1.2,Load Option Processing,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#load-option-processing
+3.1.3,Load Options,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#load-options
+3.1.4,Boot Manager Capabilities,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#boot-manager-capabilities
+3.1.5,Launching Boot#### Applications,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#launching-boot-applications
+3.1.6,Launching Boot#### Load Options Using Hot Keys,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#launching-boot-load-options-using-hot-keys
+3.1.7,Required System Preparation Applications,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#required-system-preparation-applications
+3.2,Boot Manager Policy Protocol,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#boot-manager-policy-protocol
+3.2.1,EFI_BOOT_MANAGER_POLICY_PROTOCOL,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#efi-boot-manager-policy-protocol
+3.2.2,EFI_BOOT_MANAGER_POLICY_PROTOCOL.ConnectDevicePath(),https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#efi-boot-manager-policy-protocol-connectdevicepath
+3.2.3,EFI_BOOT_MANAGER_POLICY_PROTOCOL.ConnectDeviceClass(),https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#efi-boot-manager-policy-protocol-connectdeviceclass
+3.3,Globally Defined Variables,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#globally-defined-variables
+3.4,Boot Option Recovery,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#boot-option-recovery
+3.4.1,OS-Defined Boot Option Recovery,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#os-defined-boot-option-recovery
+3.4.2,Platform-Defined Boot Option Recovery,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#platform-defined-boot-option-recovery
+3.4.3,Boot Option Variables Default Boot Behavior,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#boot-option-variables-default-boot-behavior
+3.5,Boot Mechanisms,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#boot-mechanisms
+3.5.1,Boot via the Simple File Protocol,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#boot-via-the-simple-file-protocol
+3.5.1.1,Removable Media Boot Behavior,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#removable-media-boot-behavior
+3.5.2,Boot via the Load File Protocol,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#boot-via-the-load-file-protocol
+3.5.2.1,Network Booting,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#network-booting
+3.5.2.2,Future Boot Media,https://uefi.org/specs/UEFI/2.11/03_Boot_Manager.html#future-boot-media
+4,EFI System Table,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html
+4.1,UEFI Image Entry Point,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#uefi-image-entry-point
+4.1.1,EFI_IMAGE_ENTRY_POINT,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#efi-image-entry-point
+4.2,EFI Table Header,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#efi-table-header
+4.2.1,EFI_TABLE_HEADER,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#id4
+4.3,EFI System Table,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#efi-system-table-1
+4.3.1,EFI_SYSTEM_TABLE,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#id6
+4.4,EFI Boot Services Table,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#efi-boot-services-table
+4.4.1,EFI_BOOT_SERVICES,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#efi-boot-services
+4.5,EFI Runtime Services Table,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#efi-runtime-services-table
+4.5.1,EFI_RUNTIME_SERVICES,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#efi-runtime-services
+4.6,EFI Configuration Table & Properties Table,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#efi-configuration-table-properties-table
+4.6.1,EFI_CONFIGURATION_TABLE,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#efi-configuration-table
+4.6.1.1,Industry Standard Configuration Tables,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#industry-standard-configuration-tables
+4.6.1.2,JSON Configuration Tables,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#json-configuration-tables
+4.6.1.3,Devicetree Tables,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#devicetree-tables
+4.6.2,EFI_RT_PROPERTIES_TABLE,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#efi-rt-properties-table
+4.6.3,EFI_MEMORY_ATTRIBUTES_TABLE,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#efi-memory-attributes-table
+4.6.4,EFI_CONFORMANCE_PROFILE_TABLE,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#efi-conformance-profile-table
+4.6.5,Other Configuration Tables,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#other-configuration-tables
+4.7,Image Entry Point Examples,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#image-entry-point-examples
+4.7.1,Image Entry Point Examples,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#id18
+4.7.2,UEFI Driver Model Example,https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#uefi-driver-model-example
+4.7.3,UEFI Driver Model Example (Unloadable),https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#uefi-driver-model-example-unloadable
+4.7.4,EFI Driver Model Example (Multiple Instances),https://uefi.org/specs/UEFI/2.11/04_EFI_System_Table.html#efi-driver-model-example-multiple-instances
+5,GUID Partition Table (GPT) Disk Layout,https://uefi.org/specs/UEFI/2.11/05_GUID_Partition_Table_Format.html
+5.1,GPT and MBR disk layout comparison,https://uefi.org/specs/UEFI/2.11/05_GUID_Partition_Table_Format.html#gpt-and-mbr-disk-layout-comparison
+5.2,LBA 0 Format,https://uefi.org/specs/UEFI/2.11/05_GUID_Partition_Table_Format.html#lba-0-format
+5.2.1,Legacy Master Boot Record (MBR),https://uefi.org/specs/UEFI/2.11/05_GUID_Partition_Table_Format.html#legacy-master-boot-record-mbr
+5.2.2,OS Types,https://uefi.org/specs/UEFI/2.11/05_GUID_Partition_Table_Format.html#os-types
+5.2.3,Protective MBR,https://uefi.org/specs/UEFI/2.11/05_GUID_Partition_Table_Format.html#protective-mbr
+5.2.4,Partition Information,https://uefi.org/specs/UEFI/2.11/05_GUID_Partition_Table_Format.html#partition-information
+5.3,GUID Partition Table (GPT) Disk Layout,https://uefi.org/specs/UEFI/2.11/05_GUID_Partition_Table_Format.html#guid-partition-table-gpt-disk-layout-1
+5.3.1,GPT overview,https://uefi.org/specs/UEFI/2.11/05_GUID_Partition_Table_Format.html#gpt-overview
+5.3.2,GPT Header,https://uefi.org/specs/UEFI/2.11/05_GUID_Partition_Table_Format.html#gpt-header
+5.3.3,GPT Partition Entry Array,https://uefi.org/specs/UEFI/2.11/05_GUID_Partition_Table_Format.html#gpt-partition-entry-array
+6,Block Translation Table (BTT) Layout,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html
+6.1,Block Translation Table (BTT) Background,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#block-translation-table-btt-background
+6.2,Block Translation Table (BTT) Data Structures,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#block-translation-table-btt-data-structures
+6.2.1,BTT Info Block,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#btt-info-block
+6.2.2,BTT Map Entry,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#btt-map-entry
+6.2.3,BTT Flog,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#btt-flog
+6.2.4,BTT Data Area,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#btt-data-area
+6.2.5,NVDIMM Label Protocol Address Abstraction Guid,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#nvdimm-label-protocol-address-abstraction-guid
+6.3,BTT Theory of Operation,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#btt-theory-of-operation
+6.3.1,BTT Arenas,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#btt-arenas
+6.3.2,Atomicity of Data Blocks in an Arena,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#atomicity-of-data-blocks-in-an-arena
+6.3.3,Atomicity of BTT Data Structures,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#atomicity-of-btt-data-structures
+6.3.4,Writing the Initial BTT layout,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#writing-the-initial-btt-layout
+6.3.5,Validating BTT Arenas at start-up,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#validating-btt-arenas-at-start-up
+6.3.6,Validating the Flog entries at start-up,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#validating-the-flog-entries-at-start-up
+6.3.7,Read Path,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#read-path
+6.3.8,Write Path,https://uefi.org/specs/UEFI/2.11/06_Block_Transition_Table_Layout.html#write-path
+7,Services - Boot Services,https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html
+7.1,"Event, Timer, and Task Priority Services",https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#event-timer-and-task-priority-services
+7.1.1,EFI_BOOT_SERVICES.CreateEvent(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-createevent
+7.1.2,EFI_BOOT_SERVICES.CreateEventEx(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-createeventex
+7.1.3,EFI_BOOT_SERVICES.CloseEvent(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-closeevent
+7.1.4,EFI_BOOT_SERVICES.SignalEvent(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-signalevent
+7.1.5,EFI_BOOT_SERVICES.WaitForEvent(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-waitforevent
+7.1.6,EFI_BOOT_SERVICES.CheckEvent(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-checkevent
+7.1.7,EFI_BOOT_SERVICES.SetTimer(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-settimer
+7.1.8,EFI_BOOT_SERVICES.RaiseTPL(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-raisetpl
+7.1.9,EFI_BOOT_SERVICES.RestoreTPL(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-restoretpl
+7.2,Memory Allocation Services,https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#memory-allocation-services
+7.2.1,EFI_BOOT_SERVICES.AllocatePages(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-allocatepages
+7.2.2,EFI_BOOT_SERVICES.FreePages(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-freepages
+7.2.3,EFI_BOOT_SERVICES.GetMemoryMap(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-getmemorymap
+7.2.4,EFI_BOOT_SERVICES.AllocatePool(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-allocatepool
+7.2.5,EFI_BOOT_SERVICES.FreePool(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-freepool
+7.3,Protocol Handler Services,https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#protocol-handler-services
+7.3.1,Driver Model Boot Services,https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#driver-model-boot-services
+7.3.2,EFI_BOOT_SERVICES.InstallProtocolInterface(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-installprotocolinterface
+7.3.3,EFI_BOOT_SERVICES.UninstallProtocolInterface(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-uninstallprotocolinterface
+7.3.4,EFI_BOOT_SERVICES.ReinstallProtocolInterface(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-reinstallprotocolinterface
+7.3.5,EFI_BOOT_SERVICES.RegisterProtocolNotify(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-registerprotocolnotify
+7.3.6,EFI_BOOT_SERVICES.LocateHandle(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-locatehandle
+7.3.7,EFI_BOOT_SERVICES.HandleProtocol(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-handleprotocol
+7.3.8,EFI_BOOT_SERVICES.LocateDevicePath(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-locatedevicepath
+7.3.9,EFI_BOOT_SERVICES.OpenProtocol(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-openprotocol
+7.3.10,EFI_BOOT_SERVICES.CloseProtocol(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-closeprotocol
+7.3.11,EFI_BOOT_SERVICES.OpenProtocolInformation(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-openprotocolinformation
+7.3.12,EFI_BOOT_SERVICES.ConnectController(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-connectcontroller
+7.3.13,EFI_BOOT_SERVICES.DisconnectController(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-disconnectcontroller
+7.3.14,EFI_BOOT_SERVICES.ProtocolsPerHandle(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-protocolsperhandle
+7.3.15,EFI_BOOT_SERVICES.LocateHandleBuffer(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-locatehandlebuffer
+7.3.16,EFI_BOOT_SERVICES.LocateProtocol(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-locateprotocol
+7.3.17,EFI_BOOT_SERVICES.InstallMultipleProtocolInterfaces(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-installmultipleprotocolinterfaces
+7.3.18,EFI_BOOT_SERVICES.UninstallMultipleProtocolInterfaces(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-uninstallmultipleprotocolinterfaces
+7.4,Image Services,https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#image-services
+7.4.1,EFI_BOOT_SERVICES.LoadImage(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-loadimage
+7.4.2,EFI_BOOT_SERVICES.StartImage(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-startimage
+7.4.3,EFI_BOOT_SERVICES.UnloadImage(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-unloadimage
+7.4.4,EFI_IMAGE_ENTRY_POINT,https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-image-entry-point
+7.4.5,EFI_BOOT_SERVICES.Exit(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-exit
+7.4.6,EFI_BOOT_SERVICES.ExitBootServices(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-exitbootservices
+7.5,Miscellaneous Boot Services,https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#miscellaneous-boot-services
+7.5.1,EFI_BOOT_SERVICES.SetWatchdogTimer(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-setwatchdogtimer
+7.5.2,EFI_BOOT_SERVICES.Stall(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-stall
+7.5.3,EFI_BOOT_SERVICES.CopyMem(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-copymem
+7.5.4,EFI_BOOT_SERVICES.SetMem(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-setmem
+7.5.5,EFI_BOOT_SERVICES.GetNextMonotonicCount(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-getnextmonotoniccount
+7.5.6,EFI_BOOT_SERVICES.InstallConfigurationTable(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-installconfigurationtable
+7.5.7,EFI_BOOT_SERVICES.CalculateCrc32(),https://uefi.org/specs/UEFI/2.11/07_Services_Boot_Services.html#efi-boot-services-calculatecrc32
+8,Services - Runtime Services,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html
+8.1,Runtime Services Rules and Restrictions,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#runtime-services-rules-and-restrictions
+8.1.1,"Exception for Machine Check, INIT, and NMI",https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#exception-for-machine-check-init-and-nmi
+8.2,Variable Services,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#variable-services
+8.2.1,GetVariable(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#getvariable
+8.2.2,GetNextVariableName(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#getnextvariablename
+8.2.3,SetVariable(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#setvariable
+8.2.4,QueryVariableInfo(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#queryvariableinfo
+8.2.5,Using the EFI_VARIABLE_AUTHENTICATION_3 descriptor,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#using-the-efi-variable-authentication-3-descriptor
+8.2.6,Using the EFI_VARIABLE_AUTHENTICATION_2 descriptor,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#using-the-efi-variable-authentication-2-descriptor
+8.2.7,Hardware Error Record Persistence,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#hardware-error-record-persistence
+8.2.7.1,Hardware Error Record Non-Volatile Store,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#hardware-error-record-non-volatile-store
+8.2.7.2,Hardware Error Record Variables,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#hardware-error-record-variables
+8.2.7.3,Common Platform Error Record Format,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#common-platform-error-record-format
+8.3,Time Services,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#time-services
+8.3.1,GetTime(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#gettime
+8.3.2,SetTime(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#settime
+8.3.3,GetWakeupTime(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#getwakeuptime
+8.3.4,SetWakeupTime(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#setwakeuptime
+8.4,Virtual Memory Services,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#virtual-memory-services
+8.4.1,SetVirtualAddressMap(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#setvirtualaddressmap
+8.4.2,ConvertPointer(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#convertpointer
+8.5,Miscellaneous Runtime Services,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#miscellaneous-runtime-services
+8.5.1,Reset System,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#reset-system
+8.5.1.1,ResetSystem(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#resetsystem
+8.5.2,Get Next High Monotonic Count,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#get-next-high-monotonic-count
+8.5.2.1,GetNextHighMonotonicCount(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#getnexthighmonotoniccount
+8.5.3,Update Capsule,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#update-capsule
+8.5.3.1,UpdateCapsule(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#updatecapsule
+8.5.3.2,Capsule Definition,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#capsule-definition
+8.5.3.3,EFI_MEMORY_RANGE_CAPSULE_GUID,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#efi-memory-range-capsule-guid
+8.5.3.4,QueryCapsuleCapabilities(),https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#querycapsulecapabilities
+8.5.4,Exchanging information between the OS and Firmware,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#exchanging-information-between-the-os-and-firmware
+8.5.5,Delivery of Capsules via file on Mass Storage Device,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#delivery-of-capsules-via-file-on-mass-storage-device
+8.5.6,UEFI variable reporting on the Success or any Errors encountered in processing of capsules after restart,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#uefi-variable-reporting-on-the-success-or-any-errors-encountered-in-processing-of-capsules-after-restart
+8.5.6.1,EFI_CAPSULE_REPORT_GUID,https://uefi.org/specs/UEFI/2.11/08_Services_Runtime_Services.html#efi-capsule-report-guid
+9,Protocols - EFI Loaded Image,https://uefi.org/specs/UEFI/2.11/09_Protocols_EFI_Loaded_Image.html
+9.1,EFI Loaded Image Protocol,https://uefi.org/specs/UEFI/2.11/09_Protocols_EFI_Loaded_Image.html#efi-loaded-image-protocol
+9.1.1,EFI_LOADED_IMAGE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/09_Protocols_EFI_Loaded_Image.html#id3
+9.1.2,EFI_LOADED_IMAGE_PROTOCOL.Unload(),https://uefi.org/specs/UEFI/2.11/09_Protocols_EFI_Loaded_Image.html#efi-loaded-image-protocol-unload
+9.2,EFI Loaded Image Device Path Protocol,https://uefi.org/specs/UEFI/2.11/09_Protocols_EFI_Loaded_Image.html#efi-loaded-image-device-path-protocol
+9.2.1,EFI_LOADED_IMAGE_DEVICE_PATH_PROTOCOL,https://uefi.org/specs/UEFI/2.11/09_Protocols_EFI_Loaded_Image.html#id6
+10,Protocols - Device Path Protocol,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html
+10.1,Device Path Overview,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#device-path-overview
+10.2,EFI Device Path Protocol,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-protocol
+10.3,Device Path Nodes,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#device-path-nodes
+10.3.1,Generic Device Path Structures,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#generic-device-path-structures
+10.3.2,Hardware Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#hardware-device-path
+10.3.2.1,PCI Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#pci-device-path
+10.3.2.2,PCCARD Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#pccard-device-path
+10.3.2.3,Memory Mapped Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#memory-mapped-device-path
+10.3.2.4,Vendor Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#vendor-device-path
+10.3.2.5,Controller Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#controller-device-path
+10.3.2.6,BMC Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#bmc-device-path
+10.3.3,ACPI Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#acpi-device-path
+10.3.3.1,ACPI _ADR Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#acpi-adr-device-path
+10.3.3.2,NVDIMM Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#nvdimm-device-path
+10.3.4,Messaging Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#messaging-device-path
+10.3.4.1,ATAPI Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#atapi-device-path
+10.3.4.2,SCSI Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#scsi-device-path
+10.3.4.3,Fibre Channel Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#fibre-channel-device-path
+10.3.4.4,1394 Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#device-path
+10.3.4.5,USB Device Paths,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#usb-device-paths
+10.3.4.6,SATA Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#sata-device-path
+10.3.4.7,USB Device Paths (WWID),https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#usb-device-paths-wwid
+10.3.4.8,Device Logical Unit,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#device-logical-unit
+10.3.4.9,I 2 O Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#i-2-o-device-path
+10.3.4.10,MAC Address Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#mac-address-device-path
+10.3.4.11,IPv4 Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#ipv4-device-path
+10.3.4.12,IPv6 Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#ipv6-device-path
+10.3.4.13,2. VLAN device path node,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#vlan-device-path-node
+10.3.4.14,InfiniBand Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#infiniband-device-path
+10.3.4.15,UART Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#uart-device-path
+10.3.4.16,Vendor-Defined Messaging Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#vendor-defined-messaging-device-path
+10.3.4.17,UART Flow Control Messaging Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#uart-flow-control-messaging-path
+10.3.4.18,Serial Attached SCSI (SAS) Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#serial-attached-scsi-sas-device-path
+10.3.4.19,Serial Attached SCSI (SAS) Extended Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#serial-attached-scsi-sas-extended-device-path
+10.3.4.20,iSCSI Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#iscsi-device-path
+10.3.4.21,NVM Express namespace messaging device path node,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#nvm-express-namespace-messaging-device-path-node
+10.3.4.22,Uniform Resource Identifiers (URI) Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#uniform-resource-identifiers-uri-device-path
+10.3.4.23,UFS (Universal Flash Storage) device messaging devicepath node,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#ufs-universal-flash-storage-device-messaging-devicepath-node
+10.3.4.24,SD (Secure Digital) Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#sd-secure-digital-device-path
+10.3.4.25,EFI Bluetooth Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-bluetooth-device-path
+10.3.4.26,Wireless Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#wireless-device-path
+10.3.4.27,eMMC (Embedded Multi-Media Card) Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#emmc-embedded-multi-media-card-device-path
+10.3.4.28,EFI BluetoothLE Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-bluetoothle-device-path
+10.3.4.29,DNS Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#dns-device-path
+10.3.4.30,NVDIMM Namespace path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#nvdimm-namespace-path
+10.3.4.31,REST Service Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#rest-service-device-path
+10.3.4.32,NVMe over Fabric (NVMe-oF) Namespace Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#nvme-over-fabric-nvme-of-namespace-device-path
+10.3.4.33,NVMe over Fabric (NVMe-oF) Namespace Device Path Example,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#nvme-over-fabric-nvme-of-namespace-device-path-example
+10.3.5,Media Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#media-device-path
+10.3.5.1,Hard Drive,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#hard-drive
+10.3.5.2,CD-ROM Media Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#cd-rom-media-device-path
+10.3.5.3,Vendor-Defined Media Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#vendor-defined-media-device-path
+10.3.5.4,File Path Media Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#file-path-media-device-path
+10.3.5.5,Media Protocol Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#media-protocol-device-path
+10.3.5.6,PIWG Firmware File,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#piwg-firmware-file
+10.3.5.7,PIWG Firmware Volume,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#piwg-firmware-volume
+10.3.5.8,Relative Offset Range,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#relative-offset-range
+10.3.5.9,RAM Disk,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#ram-disk
+10.3.6,BIOS Boot Specification Device Path,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#bios-boot-specification-device-path
+10.4,Device Path Generation Rules,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#device-path-generation-rules
+10.4.1,Housekeeping Rules,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#housekeeping-rules
+10.4.2,Rules with ACPI _HID and _UID,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#rules-with-acpi-hid-and-uid
+10.4.3,Rules with ACPI _ADR,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#rules-with-acpi-adr
+10.4.4,Hardware vs. Messaging Device Path Rules,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#hardware-vs-messaging-device-path-rules
+10.4.5,Media Device Path Rules,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#media-device-path-rules
+10.4.6,Other Rules,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#other-rules
+10.5,Device Path Utilities Protocol,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#device-path-utilities-protocol
+10.5.1,EFI_DEVICE_PATH_UTILITIES_PROTOCOL,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol
+10.5.2,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.GetDevicePathSize(),https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-getdevicepathsize
+10.5.3,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.DuplicateDevicePath(),https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-duplicatedevicepath
+10.5.4,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.AppendDevicePath(),https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-appenddevicepath
+10.5.5,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.AppendDeviceNode(),https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-appenddevicenode
+10.5.6,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.AppendDevicePathInstance(),https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-appenddevicepathinstance
+10.5.7,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.GetNextDevicePathInstance(),https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-getnextdevicepathinstance
+10.5.8,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.CreateDeviceNode(),https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-createdevicenode
+10.5.9,EFI_DEVICE_PATH_UTILITIES_PROTOCOL.IsDevicePathMultiInstance(),https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-utilities-protocol-isdevicepathmultiinstance
+10.6,EFI Device Path Display Format Overview,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-display-format-overview
+10.6.1,Design Discussion,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#design-discussion
+10.6.1.1,Standardized Display Format,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#standardized-display-format
+10.6.1.2,Readability,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#readability
+10.6.1.3,Round-Trip Conversion,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#round-trip-conversion
+10.6.1.4,Command-Line Parsing,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#command-line-parsing
+10.6.1.5,Text Representation Basics,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#text-representation-basics
+10.6.1.6,Text Device Node Reference,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#text-device-node-reference
+10.6.2,Device Path to Text Protocol,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#device-path-to-text-protocol
+10.6.2.1,EFI_DEVICE_PATH_TO_TEXT_PROTOCOL,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-to-text-protocol
+10.6.3,EFI_DEVICE_PATH_TO_TEXT_PROTOCOL.ConvertDeviceNodeToText(),https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-to-text-protocol-convertdevicenodetotext
+10.6.4,EFI_DEVICE_PATH_TO_TEXT_PROTOCOL.ConvertDevicePathToText(),https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-to-text-protocol-convertdevicepathtotext
+10.6.5,Device Path from Text Protocol,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#device-path-from-text-protocol
+10.6.5.1,EFI_DEVICE_PATH_FROM_TEXT_PROTOCOL,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-from-text-protocol
+10.6.5.2,EFI_DEVICE_PATH_FROM_TEXT_PROTOCOL.ConvertTextToDeviceNode(),https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-from-text-protocol-converttexttodevicenode
+10.6.5.3,EFI_DEVICE_PATH_FROM_TEXT_PROTOCOL.ConvertTextToDevicePath(,https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#efi-device-path-from-text-protocol-converttexttodevicepath
+11,Protocols - UEFI Driver Model,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html
+11.1,EFI Driver Binding Protocol,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-binding-protocol
+11.1.1,EFI_DRIVER_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#id1
+11.1.2,EFI_DRIVER_BINDING_PROTOCOL.Supported(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-binding-protocol-supported
+11.1.3,EFI_DRIVER_BINDING_PROTOCOL.Start(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-binding-protocol-start
+11.1.4,EFI_DRIVER_BINDING_PROTOCOL.Stop(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-binding-protocol-stop
+11.2,EFI Platform Driver Override Protocol,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-platform-driver-override-protocol
+11.2.1,EFI_PLATFORM_DRIVER_OVERRIDE_PROTOCOL.GetDriver(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-platform-driver-override-protocol-getdriver
+11.2.2,EFI_PLATFORM_DRIVER_OVERRIDE_PROTOCOL.GetDriverPath(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-platform-driver-override-protocol-getdriverpath
+11.2.3,EFI_PLATFORM_DRIVER_OVERRIDE_PROTOCOL.DriverLoaded(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-platform-driver-override-protocol-driverloaded
+11.3,EFI Bus Specific Driver Override Protocol,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-bus-specific-driver-override-protocol
+11.3.1,EFI_BUS_SPECIFIC_DRIVER_OVERRIDE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-bus-specific-driver-override-protocol-protocols-uefi-driver-model
+11.3.2,EFI_BUS_SPECIFIC_DRIVER_OVERRIDE_PROTOCOL.GetDriver(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-bus-specific-driver-override-protocol-getdriver
+11.4,EFI Driver Diagnostics Protocol,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-diagnostics-protocol
+11.4.1,EFI_DRIVER_DIAGNOSTICS2_PROTOCOL,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-diagnostics2-protocol
+11.4.2,EFI_DRIVER_DIAGNOSTICS2_PROTOCOL.RunDiagnostics(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-diagnostics2-protocol-rundiagnostics
+11.5,EFI Component Name Protocol,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-component-name-protocol
+11.5.1,EFI_COMPONENT_NAME2_PROTOCOL,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-component-name2-protocol
+11.5.2,EFI_COMPONENT_NAME2_PROTOCOL.GetDriverName(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-component-name2-protocol-getdrivername
+11.5.3,EFI_COMPONENT_NAME2_PROTOCOL.GetControllerName(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-component-name2-protocol-getcontrollername
+11.6,EFI Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-service-binding-protocol
+11.6.1,EFI_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-service-binding-protocol-1-protocols-uefi-driver-model
+11.6.2,EFI_SERVICE_BINDING_PROTOCOL.CreateChild(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-service-binding-protocol-createchild
+11.6.3,EFI_SERVICE_BINDING_PROTOCOL.DestroyChild(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-service-binding-protocol-destroychild
+11.7,EFI Platform to Driver Configuration Protocol,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-platform-to-driver-configuration-protocol
+11.7.1,EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#id5
+11.7.2,EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL.Query(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-platform-to-driver-configuration-protocol-query
+11.7.3,EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL.Response(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-platform-to-driver-configuration-protocol-response
+11.7.4,DMTF SM CLP ParameterTypeGuid,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#dmtf-sm-clp-parametertypeguid
+11.8,EFI Driver Supported EFI Version Protocol,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-supported-efi-version-protocol
+11.8.1,EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#id6
+11.9,EFI Driver Family Override Protocol,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-family-override-protocol
+11.9.1,Overview,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#overview
+11.9.1.1,EFI_DRIVER_FAMILY_OVERRIDE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-family-override-protocol-protocols-uefi-driver-model
+11.9.1.2,EFI_DRIVER_FAMILY_OVERRIDE_PROTOCOL.GetVersion(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-family-override-protocol-getversion
+11.10,EFI Driver Health Protocol,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-health-protocol
+11.10.1,EFI_DRIVER_HEALTH_PROTOCOL,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#id9
+11.10.2,EFI_DRIVER_HEALTH_PROTOCOL.GetHealthStatus(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-health-protocol-gethealthstatus
+11.10.3,EFI_DRIVER_HEALTH_PROTOCOL.Repair(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-driver-health-protocol-repair
+11.10.4,UEFI Boot Manager Algorithms,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#uefi-boot-manager-algorithms
+11.10.4.1,All Controllers Healthy,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#all-controllers-healthy
+11.10.4.2,Process a Controller Until Terminal StateReached,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#process-a-controller-until-terminal-statereached
+11.10.4.3,Repair Notification Function,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#repair-notification-function
+11.10.4.4,Process Message List,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#process-message-list
+11.10.4.5,Process HII Form,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#process-hii-form
+11.10.5,UEFI Driver Algorithms,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#uefi-driver-algorithms
+11.10.5.1,Driver Entry Point Updates,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#driver-entry-point-updates
+11.10.5.2,Add global variable,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#add-global-variable
+11.10.5.3,Update private context structure,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#update-private-context-structure
+11.10.5.4,Implement GetHealthStatus() service,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#implement-gethealthstatus-service
+11.10.5.5,Implement Repair() service,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#implement-repair-service
+11.11,EFI Adapter Information Protocol,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-adapter-information-protocol
+11.11.1,EFI_ADAPTER_INFORMATION_PROTOCOL,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-adapter-information-protocol-protocols-uefi-driver-model
+11.11.2,EFI_ADAPTER_INFORMATION_PROTOCOL.EFI_ADAPTER_GET_INFO(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-adapter-information-protocol-efi-adapter-get-info
+11.11.3,EFI_ADAPTER_INFORMATION_PROTOCOL.EFI_ADAPTER_INFO_SET_INFO(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-adapter-information-protocol-efi-adapter-info-set-info
+11.11.4,EFI_ADAPTER_INFORMATION_PROTOCOL. EFI_ADAPTER_INFO_GET_SUPPORTED_TYPES(),https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-adapter-information-protocol-efi-adapter-info-get-supported-types
+11.12,EFI Adapter Information Protocol Information Types,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-adapter-information-protocol-information-types
+11.12.1,Network Media State,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#network-media-state
+11.12.2,Network Boot,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#network-boot
+11.12.3,SAN MAC Address,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#san-mac-address
+11.12.4,IPV6 Support from UNDI,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#ipv6-support-from-undi
+11.12.5,Network Media Type,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#network-media-type
+11.12.6,Coherent Device Attribute Table (CDAT) Type,https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#coherent-device-attribute-table-cdat-type
+12,Protocols - Console Support,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html
+12.1,Console I/O Protocol,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#console-i-o-protocol
+12.1.1,Overview,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#overview
+12.1.2,ConsoleIn Definition,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#consolein-definition
+12.2,Simple Text Input Ex Protocol,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#simple-text-input-ex-protocol
+12.2.1,EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-input-ex-protocol
+12.2.2,EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-input-ex-protocol-reset
+12.2.3,EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.ReadKeyStrokeEx(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-input-ex-protocol-readkeystrokeex
+12.2.4,EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.SetState(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-input-ex-protocol-setstate
+12.2.5,EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.RegisterKeyNotify(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-input-ex-protocol-registerkeynotify
+12.2.6,EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.UnregisterKeyNotify(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-input-ex-protocol-unregisterkeynotify
+12.3,Simple Text Input Protocol,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#simple-text-input-protocol
+12.3.1,EFI_SIMPLE_TEXT_INPUT_PROTOCOL,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-input-protocol
+12.3.2,EFI_SIMPLE_TEXT_INPUT_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-input-protocol-reset
+12.3.3,EFI_SIMPLE_TEXT_INPUT_PROTOCOL.ReadKeyStroke(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-input-protocol-readkeystroke
+12.3.4,ConsoleOut or StandardError,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#consoleout-or-standarderror
+12.4,Simple Text Output Protocol,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#simple-text-output-protocol
+12.4.1,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-output-protocol
+12.4.2,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-reset
+12.4.3,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.OutputString(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-outputstring
+12.4.4,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.TestString(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-teststring
+12.4.5,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.QueryMode(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-querymode
+12.4.6,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.SetMode(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-setmode
+12.4.7,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.SetAttribute(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-setattribute
+12.4.8,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.ClearScreen(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-clearscreen
+12.4.9,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.SetCursorPosition(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-setcursorposition
+12.4.10,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.EnableCursor(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-enablecursor
+12.5,Simple Pointer Protocol,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#simple-pointer-protocol
+12.5.1,EFI_SIMPLE_POINTER_PROTOCOL,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-pointer-protocol
+12.5.2,EFI_SIMPLE_POINTER_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-pointer-protocol-reset
+12.5.3,EFI_SIMPLE_POINTER_PROTOCOL.GetState(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-pointer-protocol-getstate
+12.6,EFI Simple Pointer Device Paths,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-simple-pointer-device-paths
+12.7,Absolute Pointer Protocol,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#absolute-pointer-protocol
+12.7.1,EFI_ABSOLUTE_POINTER_PROTOCOL,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-absolute-pointer-protocol
+12.7.2,EFI_ABSOLUTE_POINTER_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-absolute-pointer-protocol-reset
+12.7.3,EFI_ABSOLUTE_POINTER_PROTOCOL.GetState(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-absolute-pointer-protocol-getstate
+12.8,Serial I/O Protocol,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#serial-i-o-protocol
+12.8.1,EFI_SERIAL_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-serial-io-protocol
+12.8.2,Serial Device Identification,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#serial-device-identification
+12.8.3,Serial Device Type GUIDs,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#serial-device-type-guids
+12.8.3.1,EFI_SERIAL_IO_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-serial-io-protocol-reset
+12.8.3.2,EFI_SERIAL_IO_PROTOCOL.SetAttributes(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-serial-io-protocol-setattributes
+12.8.3.3,EFI_SERIAL_IO_PROTOCOL.SetControl(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-serial-io-protocol-setcontrol
+12.8.3.4,EFI_SERIAL_IO_PROTOCOL.GetControl(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-serial-io-protocol-getcontrol
+12.8.3.5,EFI_SERIAL_IO_PROTOCOL.Write(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-serial-io-protocol-write
+12.8.3.6,EFI_SERIAL_IO_PROTOCOL.Read(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-serial-io-protocol-read
+12.9,Graphics Output Protocol,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#graphics-output-protocol
+12.9.1,Blt Buffer,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#blt-buffer
+12.9.2,EFI_GRAPHICS_OUTPUT_PROTOCOL,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-graphics-output-protocol
+12.9.2.1,EFI_GRAPHICS_OUTPUT_PROTOCOL.QueryMode(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-graphics-output-protocol-querymode
+12.9.2.2,EFI_GRAPHICS_OUTPUT_PROTOCOL.SetMode(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-graphics-output-protocol-setmode
+12.9.2.3,EFI_GRAPHICS_OUTPUT_PROTOCOL.Blt(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-graphics-output-protocol-blt
+12.9.2.4,EFI_EDID_DISCOVERED_PROTOCOL,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-edid-discovered-protocol
+12.9.2.5,EFI_EDID_ACTIVE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-edid-active-protocol
+12.9.2.6,EFI_EDID_OVERRIDE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-edid-override-protocol
+12.9.2.7,EFI_EDID_OVERRIDE_PROTOCOL.GetEdid(),https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#efi-edid-override-protocol-getedid
+12.10,Rules for PCI/AGP Devices,https://uefi.org/specs/UEFI/2.11/12_Protocols_Console_Support.html#rules-for-pci-agp-devices
+13,Protocols - Media Access,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html
+13.1,Load File Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#load-file-protocol
+13.1.1,EFI_LOAD_FILE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-load-file-protocol
+13.1.2,EFI_LOAD_FILE_PROTOCOL.LoadFile(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-load-file-protocol-loadfile
+13.2,Load File 2 Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#load-file-2-protocol
+13.2.1,EFI_LOAD_FILE2_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-load-file2-protocol
+13.2.2,EFI_LOAD_FILE2_PROTOCOL.LoadFile(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-load-file2-protocol-loadfile
+13.3,File System Format,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#file-system-format
+13.3.1,System Partition,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#system-partition
+13.3.1.1,File System Format,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#file-system-format-1
+13.3.1.2,File Names,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#file-names
+13.3.1.3,Directory Structure,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#directory-structure
+13.3.2,Partition Discovery,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#partition-discovery
+13.3.2.1,ISO-9660 and El Torito,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#iso-9660-and-el-torito
+13.3.3,Number and Location of System Partitions,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#number-and-location-of-system-partitions
+13.3.4,Media Formats,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#media-formats
+13.3.4.1,Removable Media,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#removable-media
+13.3.4.2,Diskette,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#diskette
+13.3.4.3,Hard Drive,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#hard-drive
+13.3.4.4,CD-ROM and DVD-ROM,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#cd-rom-and-dvd-rom
+13.3.4.5,Network,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#network
+13.4,Simple File System Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#simple-file-system-protocol
+13.4.1,EFI_SIMPLE_FILE_SYSTEM_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-simple-file-system-protocol
+13.4.2,EFI_SIMPLE_FILE SYSTEM_PROTOCOL.OpenVolume(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-simple-file-system-protocol-openvolume
+13.5,File Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#file-protocol
+13.5.1,EFI_FILE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol
+13.5.2,EFI_FILE_PROTOCOL.Open(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-open
+13.5.3,EFI_FILE_PROTOCOL.Close(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-close
+13.5.4,EFI_FILE_PROTOCOL.Delete(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-delete
+13.5.5,EFI_FILE_PROTOCOL.Read(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-read
+13.5.6,EFI_FILE_PROTOCOL.Write(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-write
+13.5.7,EFI_FILE_PROTOCOL.OpenEx(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-openex
+13.5.8,EFI_FILE_PROTOCOL.ReadEx(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-readex
+13.5.9,EFI_FILE_PROTOCOL.WriteEx(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-writeex
+13.5.10,EFI_FILE_PROTOCOL.FlushEx(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-flushex
+13.5.11,EFI_FILE_PROTOCOL.SetPosition(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-setposition
+13.5.12,EFI_FILE_PROTOCOL.GetPosition(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-getposition
+13.5.13,EFI_FILE_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-getinfo
+13.5.14,EFI_FILE_PROTOCOL.SetInfo(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-setinfo
+13.5.15,EFI_FILE_PROTOCOL.Flush(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-protocol-flush
+13.5.16,EFI_FILE_INFO,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-info
+13.5.17,EFI_FILE_SYSTEM_INFO,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-system-info
+13.5.18,EFI_FILE_SYSTEM_VOLUME_LABEL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-file-system-volume-label
+13.6,Tape Boot Support,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#tape-boot-support
+13.6.1,Tape I/O Support,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#tape-i-o-support
+13.6.2,Tape I/O Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#tape-i-o-protocol
+13.6.2.1,EFI_TAPE_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-tape-io-protocol
+13.6.2.2,EFI_TAPE_IO_PROTOCOL.TapeRead(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-tape-io-protocol-taperead
+13.6.2.3,EFI_TAPE_IO_PROTOCOL.TapeWrite(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-tape-io-protocol-tapewrite
+13.6.2.4,EFI_TAPE_IO_PROTOCOL.TapeRewind(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-tape-io-protocol-taperewind
+13.6.2.5,EFI_TAPE_IO_PROTOCOL.TapeSpace(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-tape-io-protocol-tapespace
+13.6.2.6,EFI_TAPE_IO_PROTOCOL.TapeWriteFM(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-tape-io-protocol-tapewritefm
+13.6.2.7,EFI_TAPE_IO_PROTOCOL.TapeReset(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-tape-io-protocol-tapereset
+13.6.3,Tape Header Format,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#tape-header-format
+13.7,Disk I/O Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#disk-i-o-protocol
+13.7.1,EFI_DISK_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-disk-io-protocol
+13.7.2,EFI_DISK_IO_PROTOCOL.ReadDisk(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-disk-io-protocol-readdisk
+13.7.3,EFI_DISK_IO_PROTOCOL.WriteDisk(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-disk-io-protocol-writedisk
+13.8,Disk I/O 2 Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#disk-i-o-2-protocol
+13.8.1,EFI_DISK_IO2_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-disk-io2-protocol
+13.8.2,EFI_DISK_IO2_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-disk-io2-protocol-cancel
+13.8.3,EFI_DISK_IO2_PROTOCOL.ReadDiskEx(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-disk-io2-protocol-readdiskex
+13.8.4,EFI_DISK_IO2_PROTOCOL.WriteDiskEx(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-disk-io2-protocol-writediskex
+13.8.5,EFI_DISK_IO2_PROTOCOL.FlushDiskEx(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-disk-io2-protocol-flushdiskex
+13.9,Block I/O Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#block-i-o-protocol
+13.9.1,EFI_BLOCK_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io-protocol
+13.9.2,EFI_BLOCK_IO_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io-protocol-reset
+13.9.3,EFI_BLOCK_IO_PROTOCOL.ReadBlocks(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io-protocol-readblocks
+13.9.4,EFI_BLOCK_IO_PROTOCOL.WriteBlocks(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io-protocol-writeblocks
+13.9.5,EFI_BLOCK_IO_PROTOCOL.FlushBlocks(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io-protocol-flushblocks
+13.10,Block I/O 2 Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#block-i-o-2-protocol
+13.10.1,EFI_BLOCK_IO2_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io2-protocol
+13.10.2,EFI_BLOCK_IO2_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io2-protocol-reset
+13.10.3,EFI_BLOCK_IO2_PROTOCOL.ReadBlocksEx(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io2-protocol-readblocksex
+13.10.4,EFI_BLOCK_IO2_PROTOCOL.WriteBlocksEx(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io2-protocol-writeblocksex
+13.10.5,EFI_BLOCK_IO2_PROTOCOL.FlushBlocksEx(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io2-protocol-flushblocksex
+13.11,Inline Cryptographic Interface Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#inline-cryptographic-interface-protocol
+13.11.1,EFI_BLOCK_IO_CRYPTO_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol
+13.11.2,EFI_BLOCK_IO_CRYPTO_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-reset
+13.11.3,EFI_BLOCK_IO_CRYPTO_PROTOCOL.GetCapabilities(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-getcapabilities
+13.11.4,EFI_BLOCK_IO_CRYPTO_PROTOCOL.SetConfiguration(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-setconfiguration
+13.11.5,EFI_BLOCK_IO_CRYPTO_PROTOCOL.GetConfiguration(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-getconfiguration
+13.11.6,EFI_BLOCK_IO_CRYPTO_PROTOCOL.ReadExtended(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-readextended
+13.11.7,EFI_BLOCK_IO_CRYPTO_PROTOCOL.WriteExtended(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-writeextended
+13.11.8,EFI_BLOCK_IO_CRYPTO_PROTOCOL.FlushBlocks(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-block-io-crypto-protocol-flushblocks
+13.12,Erase Block Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#erase-block-protocol
+13.12.1,EFI_ERASE_BLOCK_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-erase-block-protocol
+13.12.2,EFI_ERASE_BLOCK_PROTOCOL.EraseBlocks(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-erase-block-protocol-eraseblocks
+13.13,ATA Pass Thru Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#ata-pass-thru-protocol
+13.13.1,EFI_ATA_PASS_THRU_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol
+13.13.2,EFI_ATA_PASS_THRU_PROTOCOL.PassThru(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-passthru
+13.13.3,EFI_ATA_PASS_THRU_PROTOCOL.GetNextPort(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-getnextport
+13.13.4,EFI_ATA_PASS_THRU_PROTOCOL.GetNextDevice(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-getnextdevice
+13.13.5,EFI_ATA_PASS_THRU_PROTOCOL.BuildDevicePath(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-builddevicepath
+13.13.6,EFI_ATA_PASS_THRU_PROTOCOL.GetDevice(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-getdevice
+13.13.7,EFI_ATA_PASS_THRU_PROTOCOL.ResetPort(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-resetport
+13.13.8,EFI_ATA_PASS_THRU_PROTOCOL.ResetDevice(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ata-pass-thru-protocol-resetdevice
+13.14,Storage Security Command Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#storage-security-command-protocol
+13.14.1,EFI_STORAGE_SECURITY_COMMAND_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-storage-security-command-protocol
+13.14.2,EFI_STORAGE_SECURITY_COMMAND_PROTOCOL.ReceiveData(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-storage-security-command-protocol-receivedata
+13.14.3,EFI_STORAGE_SECURITY_COMMAND_PROTOCOL.SendData(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-storage-security-command-protocol-senddata
+13.15,NVM Express Pass Through Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#nvm-express-pass-through-protocol
+13.15.1,EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-nvm-express-pass-thru-protocol
+13.15.2,EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL.PassThru(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-nvm-express-pass-thru-protocol-passthru
+13.15.3,EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL.GetNextNamespace(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-nvm-express-pass-thru-protocol-getnextnamespace
+13.15.4,EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL.BuildDevicePath(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-nvm-express-pass-thru-protocol-builddevicepath
+13.15.5,EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL.GetNamespace(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-nvm-express-pass-thru-protocol-getnamespace
+13.16,SD MMC Pass Thru Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#sd-mmc-pass-thru-protocol
+13.16.1,EFI_SD_MMC_PASS_THRU_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-sd-mmc-pass-thru-protocol
+13.16.2,EFI_SD_MMC_PASS_THRU_PROTOCOL.PassThru(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-sd-mmc-pass-thru-protocol-passthru
+13.16.3,EFI_SD_MMC_PASS_THRU_PROTOCOL.GetNextSlot(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-sd-mmc-pass-thru-protocol-getnextslot
+13.16.4,EFI_SD_MMC_PASS_THRU_PROTOCOL.BuildDevicePath(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-sd-mmc-pass-thru-protocol-builddevicepath
+13.16.5,EFI_SD_MMC_PASS_THRU_PROTOCOL.GetSlotNumber(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-sd-mmc-pass-thru-protocol-getslotnumber
+13.16.6,EFI_SD_MMC_PASS_THRU_PROTOCOL.ResetDevice(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-sd-mmc-pass-thru-protocol-resetdevice
+13.17,RAM Disk Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#ram-disk-protocol
+13.17.1,EFI_RAM_DISK_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ram-disk-protocol
+13.17.2,EFI_RAM_DISK_PROTOCOL.Register(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ram-disk-protocol-register
+13.17.3,EFI_RAM_DISK_PROTOCOL.Unregister(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ram-disk-protocol-unregister
+13.18,Partition Information Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#partition-information-protocol
+13.19,NVDIMM Label Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#nvdimm-label-protocol
+13.19.1,EFI_NVDIMM_LABEL_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-nvdimm-label-protocol
+13.19.2,EFI_NVDIMM_LABEL_PROTOCOL.LabelStorageInformation(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-nvdimm-label-protocol-labelstorageinformation
+13.19.3,EFI_NVDIMM_LABEL_PROTOCOL.LabelStorageRead(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-nvdimm-label-protocol-labelstorageread
+13.19.4,EFI_NVDIMM_LABEL_PROTOCOL.LabelStorageWrite(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-nvdimm-label-protocol-labelstoragewrite
+13.19.5,Label Storage Area Description,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#label-storage-area-description
+13.19.5.1,Updating the Name of a Namespace Description,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#updating-the-name-of-a-namespace-description
+13.20,EFI UFS Device Config Protocol,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ufs-device-config-protocol
+13.20.1,EFI_UFS_DEVICE_CONFIG_PROTOCOL,https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#id117
+13.20.2,EFI_UFS_DEVICE_CONFIG_PROTOCOL.RwUfsDescriptor(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ufs-device-config-protocol-rwufsdescriptor
+13.20.3,EFI_UFS_DEVICE_CONFIG_PROTOCOL.RwUfsFlag(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ufs-device-config-protocol-rwufsflag
+13.20.4,EFI_UFS_DEVICE_CONFIG_PROTOCOL.RwUfsAttribute(),https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#efi-ufs-device-config-protocol-rwufsattribute
+14,Protocols - PCI Bus Support,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html
+14.1,PCI Root Bridge I/O Support,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-root-bridge-i-o-support
+14.1.1,PCI Root Bridge I/O Overview,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-root-bridge-i-o-overview
+14.1.2,Sample PCI Architectures,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#sample-pci-architectures
+14.2,PCI Root Bridge I/O Protocol,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-root-bridge-i-o-protocol
+14.2.1,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol
+14.2.2,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.PollMem(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-pollmem
+14.2.3,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.PollIo(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-pollio
+14.2.4,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Mem.Read(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-mem-read
+14.2.5,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Mem.Write(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-mem-write
+14.2.6,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Io.Read(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-io-read
+14.2.7,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Io.Write(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-io-write
+14.2.8,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Pci.Read(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-pci-read
+14.2.9,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Pci.Write(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-pci-write
+14.2.10,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.CopyMem(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-copymem
+14.2.11,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Map(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-map
+14.2.12,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Unmap(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-unmap
+14.2.13,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.AllocateBuffer(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-allocatebuffer
+14.2.14,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.FreeBuffer(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-freebuffer
+14.2.15,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Flush(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-flush
+14.2.16,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.GetAttributes(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-getattributes
+14.2.17,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.SetAttributes(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-setattributes
+14.2.18,EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Configuration(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-configuration
+14.2.19,PCI Root Bridge Device Paths,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-root-bridge-device-paths
+14.3,PCI Driver Model,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-driver-model
+14.3.1,PCI Driver Initialization,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-driver-initialization
+14.3.2,Driver Diagnostics Protocol,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#driver-diagnostics-protocol
+14.3.3,Component Name Protocol,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#component-name-protocol
+14.3.4,Driver Family Override Protocol,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#driver-family-override-protocol
+14.3.5,PCI Bus Drivers,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-bus-drivers
+14.3.6,Driver Binding Protocol for PCI Bus Drivers,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#driver-binding-protocol-for-pci-bus-drivers
+14.3.7,PCI Enumeration,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-enumeration
+14.3.8,PCI Device Drivers,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-device-drivers
+14.3.9,Driver Binding Protocol for PCI Device Drivers,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#driver-binding-protocol-for-pci-device-drivers
+14.4,EFI PCI I/O Protocol,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-i-o-protocol
+14.4.1,EFI_PCI_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#id32
+14.4.2,EFI_PCI_IO_PROTOCOL.PollMem(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-pollmem
+14.4.3,EFI_PCI_IO_PROTOCOL.PollIo(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-pollio
+14.4.4,EFI_PCI_IO_PROTOCOL.Mem.Read(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-mem-read
+14.4.5,EFI_PCI_IO_PROTOCOL.Mem.Write(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-mem-write
+14.4.6,EFI_PCI_IO_PROTOCOL.Io.Read(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-io-read
+14.4.7,EFI_PCI_IO_PROTOCOL.Io.Write(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-io-write
+14.4.8,EFI_PCI_IO_PROTOCOL.Pci.Read(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-pci-read
+14.4.9,EFI_PCI_IO_PROTOCOL.Pci.Write(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-pci-write
+14.4.10,EFI_PCI_IO_PROTOCOL.CopyMem(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-copymem
+14.4.11,EFI_PCI_IO_PROTOCOL.Map(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-map
+14.4.12,EFI-PCI-IO-PROTOCOL-Unmap(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-unmap
+14.4.13,EFI_PCI_IO_PROTOCOL.AllocateBuffer(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-allocatebuffer
+14.4.14,EFI_PCI_IO_PROTOCOL.FreeBuffer(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-freebuffer
+14.4.15,EFI_PCI_IO_PROTOCOL.Flush(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-flush
+14.4.16,EFI_PCI_IO_PROTOCOL.GetLocation(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-getlocation
+14.4.17,EFI_PCI_IO_PROTOCOL.Attributes(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-attributes
+14.4.18,EFI_PCI_IO_PROTOCOL.GetBarAttributes(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-getbarattributes
+14.4.19,EFI_PCI_IO_PROTOCOL.SetBarAttributes(),https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#efi-pci-io-protocol-setbarattributes
+14.4.20,PCI Device Paths,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-device-paths
+14.4.21,PCI Option ROMs,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-option-roms
+14.4.22,PCI Bus Driver Responsibilities,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-bus-driver-responsibilities
+14.4.23,PCI Device Driver Responsibilities,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-device-driver-responsibilities
+14.4.24,Nonvolatile Storage,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#nonvolatile-storage
+14.4.25,PCI Hot-Plug Events,https://uefi.org/specs/UEFI/2.11/14_Protocols_PCI_Bus_Support.html#pci-hot-plug-events
+15,Protocols - SCSI Driver Models and Bus Support,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html
+15.1,SCSI Driver Model Overview,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-driver-model-overview
+15.2,SCSI Bus Drivers,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-bus-drivers
+15.2.1,Driver Binding Protocol for SCSI Bus Drivers,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#driver-binding-protocol-for-scsi-bus-drivers
+15.2.2,SCSI Enumeration,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-enumeration
+15.3,SCSI Device Drivers,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-device-drivers
+15.3.1,Driver Binding Protocol for SCSI Device Drivers,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#driver-binding-protocol-for-scsi-device-drivers
+15.4,EFI SCSI I/O Protocol,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-scsi-i-o-protocol
+15.4.1,EFI_SCSI_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#id8
+15.4.2,EFI_SCSI_IO_PROTOCOL.GetDeviceType(),https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-scsi-io-protocol-getdevicetype
+15.4.3,EFI_SCSI_IO_PROTOCOL.GetDeviceLocation(),https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-scsi-io-protocol-getdevicelocation
+15.4.4,EFI_SCSI_IO_PROTOCOL.ResetBus(),https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-scsi-io-protocol-resetbus
+15.4.5,EFI_SCSI_IO_PROTOCOL.ResetDevice(),https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-scsi-io-protocol-resetdevice
+15.4.6,EFI_SCSI_IO_PROTOCOL.ExecuteScsiCommand(),https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-scsi-io-protocol-executescsicommand
+15.5,SCSI Device Paths,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-device-paths
+15.5.1,SCSI Device Path Example,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-device-path-example
+15.5.2,ATAPI Device Path Example,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#atapi-device-path-example
+15.5.3,Fibre Channel Device Path Example,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#fibre-channel-device-path-example
+15.5.4,InfiniBand Device Path Example,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#infiniband-device-path-example
+15.6,SCSI Pass Thru Device Paths,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#scsi-pass-thru-device-paths
+15.7,Extended SCSI Pass Thru Protocol,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#extended-scsi-pass-thru-protocol
+15.7.1,EFI_EXT_SCSI_PASS_THRU_PROTOCOL,https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol
+15.7.2,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.PassThru(),https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-passthru
+15.7.3,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.GetNextTargetLun(),https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-getnexttargetlun
+15.7.4,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.BuildDevicePath(),https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-builddevicepath
+15.7.5,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.GetTargetLun(),https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-gettargetlun
+15.7.6,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.ResetChannel(),https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-resetchannel
+15.7.7,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.ResetTargetLun(),https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-resettargetlun
+15.7.8,EFI_EXT_SCSI_PASS_THRU_PROTOCOL.GetNextTarget(),https://uefi.org/specs/UEFI/2.11/15_Protocols_SCSI_Driver_Models_and_Bus_Support.html#efi-ext-scsi-pass-thru-protocol-getnexttarget
+16,Protocols - iSCSI Boot,https://uefi.org/specs/UEFI/2.11/16_Protocols_iSCSI_Boot.html
+16.1,Overview,https://uefi.org/specs/UEFI/2.11/16_Protocols_iSCSI_Boot.html#overview
+16.1.1,iSCSI UEFI Driver Layering,https://uefi.org/specs/UEFI/2.11/16_Protocols_iSCSI_Boot.html#iscsi-uefi-driver-layering
+16.2,EFI iSCSI Initiator Name Protocol,https://uefi.org/specs/UEFI/2.11/16_Protocols_iSCSI_Boot.html#efi-iscsi-initiator-name-protocol
+16.2.1,EFI_ISCSI_INITIATOR_NAME_PROTOCOL,https://uefi.org/specs/UEFI/2.11/16_Protocols_iSCSI_Boot.html#id4
+16.2.2,EFI_ISCSI_INITIATOR_NAME_PROTOCOL. Get(),https://uefi.org/specs/UEFI/2.11/16_Protocols_iSCSI_Boot.html#efi-iscsi-initiator-name-protocol-get
+16.2.3,EFI_ISCSI_INITIATOR_NAME_PROTOCOL.Set(),https://uefi.org/specs/UEFI/2.11/16_Protocols_iSCSI_Boot.html#efi-iscsi-initiator-name-protocol-set
+17,Protocols - USB Support,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html
+17.1,USB2 Host Controller Protocol,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#usb2-host-controller-protocol
+17.1.1,USB Host Controller Protocol Overview,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#usb-host-controller-protocol-overview
+17.1.2,EFI_USB2_HC_PROTOCOL,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol
+17.1.3,EFI_USB2_HC_PROTOCOL.GetCapability(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-getcapability
+17.1.4,EFI_USB2_HC_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-reset
+17.1.5,EFI_USB2_HC_PROTOCOL.GetState(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-getstate
+17.1.6,EFI_USB2_HC_PROTOCOL.SetState(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-setstate
+17.1.7,EFI_USB2_HC_PROTOCOL.ControlTransfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-controltransfer
+17.1.8,EFI_USB2_HC_PROTOCOL.BulkTransfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-bulktransfer
+17.1.9,EFI_USB2_HC_PROTOCOL.AsyncInterruptTransfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-asyncinterrupttransfer
+17.1.10,EFI_USB2_HC_PROTOCOL.SyncInterruptTransfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-syncinterrupttransfer
+17.1.11,EFI_USB2_HC_PROTOCOL.IsochronousTransfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-isochronoustransfer
+17.1.12,EFI_USB2_HC_PROTOCOL.AsyncIsochronousTransfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-asyncisochronoustransfer
+17.1.13,EFI_USB2_HC_PROTOCOL.GetRootHubPortStatus(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-getroothubportstatus
+17.1.14,EFI_USB2_HC_PROTOCOL.SetRootHubPortFeature(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-setroothubportfeature
+17.1.15,EFI_USB2_HC_PROTOCOL.ClearRootHubPortFeature(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb2-hc-protocol-clearroothubportfeature
+17.2,USB Driver Model,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#usb-driver-model
+17.2.1,Scope,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#scope
+17.2.2,USB Bus Driver,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#usb-bus-driver
+17.2.2.1,USB Bus Driver Entry Point,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#usb-bus-driver-entry-point
+17.2.2.2,Driver Binding Protocol for USB Bus Drivers,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#driver-binding-protocol-for-usb-bus-drivers
+17.2.2.3,USB Hot-Plug Event,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#usb-hot-plug-event
+17.2.2.4,USB Bus Enumeration,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#usb-bus-enumeration
+17.2.3,USB Device Driver,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#usb-device-driver
+17.2.3.1,USB Device Driver Entry Point,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#usb-device-driver-entry-point
+17.2.3.2,Driver Binding Protocol for USB DeviceDrivers,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#driver-binding-protocol-for-usb-devicedrivers
+17.2.4,USB I/O Protocol,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#usb-i-o-protocol
+17.2.5,EFI_USB_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol
+17.2.6,EFI_USB_IO_PROTOCOL.UsbControlTransfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbcontroltransfer
+17.2.7,EFI_USB_IO_PROTOCOL.UsbBulkTransfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbbulktransfer
+17.2.8,EFI_USB_IO_PROTOCOL.UsbAsyncInterruptTransfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbasyncinterrupttransfer
+17.2.9,EFI_USB_IO_PROTOCOL.UsbSyncInterruptTransfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbsyncinterrupttransfer
+17.2.10,EFI_USB_IO_PROTOCOL.UsbIsochronousTransfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbisochronoustransfer
+17.2.11,EFI_USB_IO_PROTOCOL.UsbAsyncIsochronousTransfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbasyncisochronoustransfer
+17.2.12,EFI_USB_IO_PROTOCOL.UsbGetDeviceDescriptor(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbgetdevicedescriptor
+17.2.13,EFI_USB_IO_PROTOCOL.UsbGetConfigDescriptor(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbgetconfigdescriptor
+17.2.14,EFI_USB_IO_PROTOCOL.UsbGetInterfaceDescriptor(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbgetinterfacedescriptor
+17.2.15,EFI_USB_IO_PROTOCOL.UsbGetEndpointDescriptor(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbgetendpointdescriptor
+17.2.16,EFI_USB_IO_PROTOCOL.UsbGetStringDescriptor(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbgetstringdescriptor
+17.2.17,EFI_USB_IO_PROTOCOL.UsbGetSupportedLanguages(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbgetsupportedlanguages
+17.2.18,EFI_USB_IO_PROTOCOL.UsbPortReset(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usb-io-protocol-usbportreset
+17.3,USB Function Protocol,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#usb-function-protocol
+17.3.1,EFI_USBFN_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol
+17.3.2,EFI_USBFN_IO_PROTOCOL.DetectPort(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-detectport
+17.3.3,EFI_USBFN_IO_PROTOCOL.ConfigureEnableEndpoints(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-configureenableendpoints
+17.3.4,EFI_USBFN_IO_PROTOCOL.GetEndpointMaxPacketSize(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-getendpointmaxpacketsize
+17.3.5,EFI_USBFN_IO_PROTOCOL.GetDeviceInfo(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-getdeviceinfo
+17.3.6,EFI_USBFN_IO_PROTOCOL.GetVendorIdProductId(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-getvendoridproductid
+17.3.7,EFI_USBFN_IO_PROTOCOL.AbortTransfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-aborttransfer
+17.3.8,EFI_USBFN_IO_PROTOCOL.GetEndpointStallState(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-getendpointstallstate
+17.3.9,EFI_USBFN_IO_PROTOCOL.SetEndpointStallState(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-setendpointstallstate
+17.3.10,EFI_USBFN_IO_PROTOCOL.EventHandler(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-eventhandler
+17.3.11,EFI_USBFN_IO_PROTOCOL.Transfer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-transfer
+17.3.12,EFI_USBFN_IO_PROTOCOL.GetMaxTransferSize(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-getmaxtransfersize
+17.3.13,EFI_USBFN_IO_PROTOCOL.AllocateTransferBuffer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-allocatetransferbuffer
+17.3.14,EFI_USBFN_IO_PROTOCOL.FreeTransferBuffer(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-freetransferbuffer
+17.3.15,EFI_USBFN_IO_PROTOCOL.StartController(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-startcontroller
+17.3.16,EFI_USBFN_IO_PROTOCOL.StopController(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-stopcontroller
+17.3.16.1,Description,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#description
+17.3.17,EFI_USBFN_IO_PROTOCOL.SetEndpointPolicy(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-setendpointpolicy
+17.3.18,EFI_USBFN_IO_PROTOCOL.GetEndpointPolicy(),https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#efi-usbfn-io-protocol-getendpointpolicy
+17.3.19,USB Function Sequence Diagram,https://uefi.org/specs/UEFI/2.11/17_Protocols_USB_Support.html#usb-function-sequence-diagram
+18,Protocols - Debugger Support,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html
+18.1,Overview,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#overview
+18.2,EFI Debug Support Protocol,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debug-support-protocol
+18.2.1,EFI Debug Support Protocol Overview,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debug-support-protocol-overview
+18.2.2,EFI_DEBUG_SUPPORT_PROTOCOL,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#id5
+18.2.3,EFI_DEBUG_SUPPORT_PROTOCOL.GetMaximumProcessorIndex(),https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debug-support-protocol-getmaximumprocessorindex
+18.2.4,EFI_DEBUG_SUPPORT_PROTOCOL.RegisterPeriodicCallback(),https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debug-support-protocol-registerperiodiccallback
+18.2.5,EFI_DEBUG_SUPPORT_PROTOCOL.RegisterExceptionCallback(),https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debug-support-protocol-registerexceptioncallback
+18.2.6,EFI_DEBUG_SUPPORT_PROTOCOL.InvalidateInstructionCache(),https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debug-support-protocol-invalidateinstructioncache
+18.3,EFI Debugport Protocol,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debugport-protocol
+18.3.1,EFI Debugport Overview,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debugport-overview
+18.3.2,EFI_DEBUGPORT_PROTOCOL,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#id13
+18.3.3,EFI_DEBUGPORT_PROTOCOL.Reset(),https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debugport-protocol-reset
+18.3.4,EFI_DEBUGPORT_PROTOCOL.Write(),https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debugport-protocol-write
+18.3.5,EFI_DEBUGPORT_PROTOCOL.Read(),https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debugport-protocol-read
+18.3.6,EFI_DEBUGPORT_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debugport-protocol-poll
+18.3.7,Debugport Device Path,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#debugport-device-path
+18.3.8,EFI Debugport Variable,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debugport-variable
+18.4,EFI Debug Support Table,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-debug-support-table
+18.4.1,Overview,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#overview-1
+18.4.2,EFI System Table Location,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-system-table-location
+18.4.3,EFI Image Info,https://uefi.org/specs/UEFI/2.11/18_Protocols_Debugger_Support.html#efi-image-info
+19,Protocols - Compression Algorithm Specification,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html
+19.1,Algorithm Overview,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#algorithm-overview
+19.2,Data Format,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#data-format
+19.2.1,Bit Order,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#bit-order
+19.2.2,Overall Structure,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#overall-structure
+19.2.3,Block Structure,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#block-structure
+19.2.3.1,Block Header,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#block-header
+19.2.3.2,Block Body,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#block-body
+19.3,Compressor Design,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#compressor-design
+19.3.1,Overall Process,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#overall-process
+19.3.2,String Info Log,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#string-info-log
+19.3.2.1,Data Structures,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#data-structures
+19.3.2.2,Searching the Tree,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#searching-the-tree
+19.3.2.3,Adding String Info,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#adding-string-info
+19.3.2.4,Deleting String Info,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#deleting-string-info
+19.3.3,Huffman Code Generation,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#huffman-code-generation
+19.3.3.1,Huffman Tree Generation,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#huffman-tree-generation
+19.3.3.2,Code Length Adjustment,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#code-length-adjustment
+19.3.3.3,Code Generation,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#code-generation
+19.4,Decompressor Design,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#decompressor-design
+19.5,Decompress Protocol,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#decompress-protocol
+19.5.1,EFI_DECOMPRESS_PROTOCOL,https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#efi-decompress-protocol
+19.5.2,EFI_DECOMPRESS_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#efi-decompress-protocol-getinfo
+19.5.3,EFI_DECOMPRESS_PROTOCOL.Decompress(),https://uefi.org/specs/UEFI/2.11/19_Protocols_Compression_Algorithm_Specification.html#efi-decompress-protocol-decompress
+20,Protocols - ACPI Protocols,https://uefi.org/specs/UEFI/2.11/20_Protocols_ACPI_Protocols.html
+20.1,EFI_ACPI_TABLE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/20_Protocols_ACPI_Protocols.html#efi-acpi-table-protocol
+20.2,EFI_ACPI_TABLE_PROTOCOL.InstallAcpiTable(),https://uefi.org/specs/UEFI/2.11/20_Protocols_ACPI_Protocols.html#efi-acpi-table-protocol-installacpitable
+20.3,EFI_ACPI_TABLE_PROTOCOL.UninstallAcpiTable(),https://uefi.org/specs/UEFI/2.11/20_Protocols_ACPI_Protocols.html#efi-acpi-table-protocol-uninstallacpitable
+21,Protocols - String Services,https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html
+21.1,Unicode Collation Protocol,https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html#unicode-collation-protocol
+21.1.1,EFI_UNICODE_COLLATION_PROTOCOL,https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html#efi-unicode-collation-protocol
+21.1.2,EFI_UNICODE_COLLATION_PROTOCOL.StriColl(),https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html#efi-unicode-collation-protocol-stricoll
+21.1.3,EFI_UNICODE_COLLATION_PROTOCOL.MetaiMatch(),https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html#efi-unicode-collation-protocol-metaimatch
+21.1.4,EFI_UNICODE_COLLATION_PROTOCOL.StrLwr(),https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html#efi-unicode-collation-protocol-strlwr
+21.1.5,EFI_UNICODE_COLLATION_PROTOCOL.StrUpr(),https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html#efi-unicode-collation-protocol-strupr
+21.1.6,EFI_UNICODE_COLLATION_PROTOCOL.FatToStr(),https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html#efi-unicode-collation-protocol-fattostr
+21.1.7,EFI_UNICODE_COLLATION_PROTOCOL.StrToFat(),https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html#efi-unicode-collation-protocol-strtofat
+21.2,Regular Expression Protocol,https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html#regular-expression-protocol
+21.2.1,EFI_REGULAR_EXPRESSION_PROTOCOL,https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html#efi-regular-expression-protocol
+21.2.2,EFI_REGULAR_EXPRESSION_PROTOCOL.MatchString(),https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html#efi-regular-expression-protocol-matchstring
+21.2.3,EFI_REGULAR_EXPRESSION_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html#efi-regular-expression-protocol-getinfo
+21.2.4,EFI Regular Expression Syntax Type Definitions,https://uefi.org/specs/UEFI/2.11/21_Protocols_String_Services.html#efi-regular-expression-syntax-type-definitions
+22,EFI Byte Code Virtual Machine,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html
+22.1,Overview,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#overview
+22.1.1,Processor Architecture Independence,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#processor-architecture-independence
+22.1.2,OS Independent,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#os-independent
+22.1.3,EFI Compliant,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#efi-compliant
+22.1.4,Coexistence of Legacy Option ROMs,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#coexistence-of-legacy-option-roms
+22.1.5,Relocatable Image,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#relocatable-image
+22.1.6,Size Restrictions Based on Memory Available,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#size-restrictions-based-on-memory-available
+22.2,Memory Ordering,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#memory-ordering
+22.3,Virtual Machine Registers,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#virtual-machine-registers
+22.4,Natural Indexing,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#natural-indexing
+22.4.1,Sign Bit,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#sign-bit
+22.4.2,Bits Assigned to Natural Units,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#bits-assigned-to-natural-units
+22.4.3,Constant,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#constant
+22.4.4,Natural Units,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#natural-units
+22.5,EBC Instruction Operands,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ebc-instruction-operands
+22.5.1,Direct Operands,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#direct-operands
+22.5.2,Indirect Operands,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#indirect-operands
+22.5.3,Indirect with Index Operands,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#indirect-with-index-operands
+22.5.4,Immediate Operands,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#immediate-operands
+22.6,EBC Instruction Syntax,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ebc-instruction-syntax
+22.7,Instruction Encoding,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#instruction-encoding
+22.7.1,Instruction Opcode Byte Encoding,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#instruction-opcode-byte-encoding
+22.7.2,Instruction Operands Byte Encoding,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#instruction-operands-byte-encoding
+22.7.3,Index/Immediate Data Encoding,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#index-immediate-data-encoding
+22.8,EBC Instruction Set,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ebc-instruction-set
+22.8.1,ADD,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#add
+22.8.2,AND,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#and
+22.8.3,ASHR,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ashr
+22.8.4,BREAK,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#break
+22.8.5,CALL,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#call
+22.8.6,CMP,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#cmp
+22.8.7,CMPI,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#cmpi
+22.8.8,DIV,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#div
+22.8.9,DIVU,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#divu
+22.8.10,EXTNDB,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#extndb
+22.8.11,EXTNDD,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#extndd
+22.8.12,EXTNDW,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#extndw
+22.8.13,JMP,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#jmp
+22.8.14,JMP8,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#jmp8
+22.8.15,LOADSP,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#loadsp
+22.8.16,MOD,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#mod
+22.8.17,MODU,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#modu
+22.8.18,MOV,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#mov
+22.8.19,MOVI,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#movi
+22.8.20,MOVIn,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#movin
+22.8.21,MOVn,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#movn
+22.8.22,MOVREL,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#movrel
+22.8.23,MOVsn,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#movsn
+22.8.24,MUL,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#mul
+22.8.25,MULU,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#mulu
+22.8.26,NEG,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#neg
+22.8.27,NOT,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#not
+22.8.28,OR,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#or
+22.8.29,POP,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#pop
+22.8.30,POPn,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#popn
+22.8.31,PUSH,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#push
+22.8.32,PUSHn,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#pushn
+22.8.33,RET,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ret
+22.8.34,SHL,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#shl
+22.8.35,SHR,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#shr
+22.8.36,STORESP,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#storesp
+22.8.37,SUB,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#sub
+22.8.38,XOR,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#xor
+22.9,Runtime and Software Conventions,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#runtime-and-software-conventions
+22.9.1,Calling Outside VM,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#calling-outside-vm
+22.9.2,Calling Inside VM,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#calling-inside-vm
+22.9.3,Parameter Passing,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#parameter-passing
+22.9.4,Return Values,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#return-values
+22.9.5,Binary Format,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#binary-format
+22.10,Architectural Requirements,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#architectural-requirements
+22.10.1,EBC Image Requirements,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ebc-image-requirements
+22.10.2,EBC Execution Interfacing Requirements,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ebc-execution-interfacing-requirements
+22.10.3,Interfacing Function Parameters Requirements,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#interfacing-function-parameters-requirements
+22.10.4,Function Return Requirements,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#function-return-requirements
+22.10.5,Function Return Values Requirements,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#function-return-values-requirements
+22.11,EBC Interpreter Protocol,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ebc-interpreter-protocol
+22.11.1,EFI_EBC_PROTOCOL,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#efi-ebc-protocol
+22.11.2,EFI_EBC_PROTOCOL.CreateThunk(),https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#efi-ebc-protocol-createthunk
+22.11.3,EFI_EBC_PROTOCOL.UnloadImage(),https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#efi-ebc-protocol-unloadimage
+22.11.4,EFI_EBC_PROTOCOL.RegisterICacheFlush(),https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#efi-ebc-protocol-registericacheflush
+22.11.5,EFI_EBC_PROTOCOL.GetVersion(),https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#efi-ebc-protocol-getversion
+22.12,EBC Tools,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ebc-tools
+22.12.1,EBC C Compiler,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ebc-c-compiler
+22.12.2,C Coding Convention,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#c-coding-convention
+22.12.3,EBC Interface Assembly Instructions,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ebc-interface-assembly-instructions
+22.12.4,Stack Maintenance and Argument Passing,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#stack-maintenance-and-argument-passing
+22.12.5,Native to EBC Arguments Calling Convention,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#native-to-ebc-arguments-calling-convention
+22.12.6,EBC to Native Arguments Calling Convention,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ebc-to-native-arguments-calling-convention
+22.12.7,EBC to EBC Arguments Calling Convention,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ebc-to-ebc-arguments-calling-convention
+22.12.8,Function Returns,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#function-returns
+22.12.9,Function Return Values,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#function-return-values
+22.12.10,Thunking,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#thunking
+22.12.10.1,Thunking EBC to Native Code,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#thunking-ebc-to-native-code
+22.12.10.2,Thunking Native Code to EBC,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#thunking-native-code-to-ebc
+22.12.10.3,Thunking EBC to EBC,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#thunking-ebc-to-ebc
+22.12.11,EBC Linker,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#ebc-linker
+22.12.12,Image Loader,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#image-loader
+22.12.13,Debug Support,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#debug-support
+22.13,VM Exception Handling,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#vm-exception-handling
+22.13.1,Divide By 0 Exception,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#divide-by-0-exception
+22.13.2,Debug Break Exception,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#debug-break-exception
+22.13.3,Invalid Opcode Exception,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#invalid-opcode-exception
+22.13.4,Stack Fault Exception,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#stack-fault-exception
+22.13.5,Alignment Exception,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#alignment-exception
+22.13.6,Instruction Encoding Exception,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#instruction-encoding-exception
+22.13.7,Bad Break Exception,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#bad-break-exception
+22.13.8,Undefined Exception,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#undefined-exception
+22.14,Option ROM Formats,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#option-rom-formats
+22.14.1,EFI Drivers for PCI Add-in Cards,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#efi-drivers-for-pci-add-in-cards
+22.14.2,Non-PCI Bus Support,https://uefi.org/specs/UEFI/2.11/22_EFI_Byte_Code_Virtual_Machine.html#non-pci-bus-support
+23,Firmware Update and Reporting,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html
+23.1,Firmware Management Protocol,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#firmware-management-protocol
+23.1.1,EFI_FIRMWARE_MANAGEMENT_PROTOCOL,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol
+23.1.2,EFI_FIRMWARE_MANAGEMENT_PROTOCOL.GetImageInfo(),https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol-getimageinfo
+23.1.3,EFI_FIRMWARE_MANAGEMENT_PROTOCOL.GetImage(),https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol-getimage
+23.1.4,EFI_FIRMWARE_MANAGEMENT_PROTOCOL.SetImage(),https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol-setimage
+23.1.5,EFI_FIRMWARE_MANAGEMENT_PROTOCOL.CheckImage(),https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol-checkimage
+23.1.6,EFI_FIRMWARE_MANAGEMENT_PROTOCOL.GetPackageInfo(),https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol-getpackageinfo
+23.1.7,EFI_FIRMWARE_MANAGEMENT_PROTOCOL.SetPackageInfo(),https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#efi-firmware-management-protocol-setpackageinfo
+23.2,Dependency Expression Instruction Set,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#dependency-expression-instruction-set
+23.2.1,PUSH_GUID,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#push-guid
+23.2.2,PUSH_VERSION,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#push-version
+23.2.3,DECLARE_VERSION_NAME,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#declare-version-name
+23.2.4,AND,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#and
+23.2.5,OR,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#or
+23.2.6,NOT,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#not
+23.2.7,TRUE,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#true
+23.2.8,FALSE,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#false
+23.2.9,EQ,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#eq
+23.2.10,GT,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#gt
+23.2.11,GTE,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#gte
+23.2.12,LT,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#lt
+23.2.13,LTE,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#lte
+23.2.14,END,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#end
+23.2.15,DECLARE_LENGTH,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#declare-length
+23.3,Delivering Capsules Containing Updates to Firmware Management Protocol,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#delivering-capsules-containing-updates-to-firmware-management-protocol
+23.3.1,EFI_FIRMWARE_MANAGEMENT_CAPSULE_ID_GUID,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#efi-firmware-management-capsule-id-guid
+23.3.2,DEFINED FIRMWARE MANAGEMENT PROTOCOL DATA CAPSULE STRUCTURE,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#defined-firmware-management-protocol-data-capsule-structure
+23.3.3,Firmware Processing of the Capsule Identified by EFI_FIRMWARE_MANAGEMENT_CAPSULE_ID_GUID,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#firmware-processing-of-the-capsule-identified-by-efi-firmware-management-capsule-id-guid
+23.4,EFI System Resource Table,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#efi-system-resource-table
+23.4.1,EFI_SYSTEM_RESOURCE_TABLE,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#id30
+23.4.2,Adding and Removing Devices from the ESRT,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#adding-and-removing-devices-from-the-esrt
+23.4.3,ESRT and Firmware Management Protocol,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#esrt-and-firmware-management-protocol
+23.4.4,Mapping Firmware Management Protocol Descriptors to ESRT Entries,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#mapping-firmware-management-protocol-descriptors-to-esrt-entries
+23.5,Delivering Capsule Containing JSON payload,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#delivering-capsule-containing-json-payload
+23.5.1,EFI_JSON_CAPSULE_ID_GUID,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#efi-json-capsule-id-guid
+23.5.2,Defined JSON Capsule Data Structure,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#defined-json-capsule-data-structure
+23.5.3,Firmware Processing of the Capsule Identified by EFI_JSON_CAPSULE_ID_GUID,https://uefi.org/specs/UEFI/2.11/23_Firmware_Update_and_Reporting.html#firmware-processing-of-the-capsule-identified-by-efi-json-capsule-id-guid
+24,"Network Protocols - SNP, PXE, BIS and HTTP Boot",https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html
+24.1,Simple Network Protocol,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#simple-network-protocol
+24.1.1,EFI_SIMPLE_NETWORK_PROTOCOL,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-protocol
+24.1.2,EFI_SIMPLE_NETWORK.Start(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-start
+24.1.3,EFI_SIMPLE_NETWORK.Stop(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-stop
+24.1.4,EFI_SIMPLE_NETWORK.Initialize(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-initialize
+24.1.5,EFI_SIMPLE_NETWORK.Reset(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-reset
+24.1.6,EFI_SIMPLE_NETWORK.Shutdown(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-shutdown
+24.1.7,EFI_SIMPLE_NETWORK.ReceiveFilters(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-receivefilters
+24.1.8,EFI_SIMPLE_NETWORK.StationAddress(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-stationaddress
+24.1.9,EFI_SIMPLE_NETWORK.Statistics(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-statistics
+24.1.10,EFI_SIMPLE_NETWORK.MCastIPtoMAC(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-mcastiptomac
+24.1.11,EFI_SIMPLE_NETWORK.NvData(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-nvdata
+24.1.12,EFI_SIMPLE_NETWORK.GetStatus(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-getstatus
+24.1.13,EFI_SIMPLE_NETWORK.Transmit(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-transmit
+24.1.14,EFI_SIMPLE_NETWORK.Receive(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-simple-network-receive
+24.2,Network Interface Identifier Protocol,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#network-interface-identifier-protocol
+24.2.1,EFI_NETWORK_INTERFACE_IDENTIFIER_PROTOCOL,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-network-interface-identifier-protocol
+24.3,PXE Base Code Protocol,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#pxe-base-code-protocol
+24.3.1,EFI_PXE_BASE_CODE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol
+24.3.2,DHCP Packet Data Types,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#dhcp-packet-data-types
+24.3.3,IP Receive Filter Settings,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#ip-receive-filter-settings
+24.3.4,ARP Cache Entries,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#arp-cache-entries
+24.3.5,Filter Operations for UDP Read/Write Functions,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#filter-operations-for-udp-read-write-functions
+24.3.6,EFI_PXE_BASE_CODE_PROTOCOL.Start(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-start
+24.3.7,EFI_PXE_BASE_CODE_PROTOCOL.Stop(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-stop
+24.3.8,EFI_PXE_BASE_CODE_PROTOCOL.Dhcp(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-dhcp
+24.3.9,EFI_PXE_BASE_CODE_PROTOCOL.Discover(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-discover
+24.3.10,EFI_PXE_BASE_CODE_PROTOCOL.Mtftp(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-mtftp
+24.3.11,EFI_PXE_BASE_CODE_PROTOCOL.UdpWrite(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-udpwrite
+24.3.12,EFI_PXE_BASE_CODE_PROTOCOL.UdpRead(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-udpread
+24.3.13,EFI_PXE_BASE_CODE_PROTOCOL.SetIpFilter(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-setipfilter
+24.3.14,EFI_PXE_BASE_CODE_PROTOCOL.Arp(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-arp
+24.3.15,EFI_PXE_BASE_CODE_PROTOCOL.SetParameters(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-setparameters
+24.3.16,EFI_PXE_BASE_CODE_PROTOCOL.SetStationIp(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-setstationip
+24.3.17,EFI_PXE_BASE_CODE_PROTOCOL.SetPackets(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-setpackets
+24.3.18,Netboot6,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#netboot6
+24.3.18.1,DHCP6 options for PXE,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#dhcp6-options-for-pxe
+24.3.18.2,IPv6-based PXE boot,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#ipv6-based-pxe-boot
+24.3.18.3,Proxy DHCP6,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#proxy-dhcp6
+24.4,PXE Base Code Callback Protocol,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#pxe-base-code-callback-protocol
+24.4.1,EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-callback-protocol
+24.4.2,EFI_PXE_BASE_CODE_CALLBACK.Callback(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-callback-callback
+24.5,Boot Integrity Services Protocol,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#boot-integrity-services-protocol
+24.5.1,EFI_BIS_PROTOCOL,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol
+24.5.2,EFI_BIS_PROTOCOL.Initialize(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-initialize
+24.5.3,EFI_BIS_PROTOCOL.Shutdown(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-shutdown
+24.5.4,EFI_BIS_PROTOCOL.Free(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-free
+24.5.5,EFI_BIS_PROTOCOL.GetBootObjectAuthorizationCertificate(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-getbootobjectauthorizationcertificate
+24.5.6,EFI_BIS_PROTOCOL.GetBootObjectAuthorizationCheckFlag(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-getbootobjectauthorizationcheckflag
+24.5.7,EFI_BIS_PROTOCOL.GetBootObjectAuthorizationUpdateToken(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-getbootobjectauthorizationupdatetoken
+24.5.8,EFI_BIS_PROTOCOL.GetSignatureInfo(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-getsignatureinfo
+24.5.9,EFI_BIS_PROTOCOL.UpdateBootObjectAuthorization(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-updatebootobjectauthorization
+24.5.10,EFI_BIS_PROTOCOL.VerifyBootObject(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-verifybootobject
+24.5.11,EFI_BIS_PROTOCOL.VerifyObjectWithCredential(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-bis-protocol-verifyobjectwithcredential
+24.6,DHCP options for ISCSI on IPV6,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#dhcp-options-for-iscsi-on-ipv6
+24.7,HTTP Boot,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#http-boot
+24.7.1,Boot from URL,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#boot-from-url
+24.7.2,Concept configuration for a typical HTTP Bootscenario,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#concept-configuration-for-a-typical-http-bootscenario
+24.7.2.1,Use in Corporate environment,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#use-in-corporate-environment
+24.7.2.2,Use case in Home environment,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#use-case-in-home-environment
+24.7.3,Protocol Layout for UEFI HTTP Boot Clientconcept configuration for a typical HTTP Boot scenario,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#protocol-layout-for-uefi-http-boot-clientconcept-configuration-for-a-typical-http-boot-scenario
+24.7.3.1,Device Path,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#device-path
+24.7.4,Concept of Message Exchange in a typical HTTPBoot scenario (IPv4 in Corporate Environment),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#concept-of-message-exchange-in-a-typical-httpboot-scenario-ipv4-in-corporate-environment
+24.7.4.1,Message exchange between EFI Client and DHCPserver using DHCP Client Extensions,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#message-exchange-between-efi-client-and-dhcpserver-using-dhcp-client-extensions
+24.7.5,Priority1,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#priority1
+24.7.6,Priority2,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#priority2
+24.7.7,Priority3,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#priority3
+24.7.8,Priority4,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#priority4
+24.7.8.1,Message exchange between UEFI Client and DHCP server not using DHCP Client Extensions,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#message-exchange-between-uefi-client-and-dhcp-server-not-using-dhcp-client-extensions
+24.7.8.2,Message in DNS Query/Reply,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#message-in-dns-query-reply
+24.7.8.3,Message in HTTP Download,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#message-in-http-download
+24.7.9,Concept of Message Exchange in HTTP Boot scenario (IPv6),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#concept-of-message-exchange-in-http-boot-scenario-ipv6
+24.7.9.1,Message exchange between EFI Client and DHCPv6 server with DHCP Client extensions,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#message-exchange-between-efi-client-and-dhcpv6-server-with-dhcp-client-extensions
+24.7.9.2,Message exchange between UEFI Client and DHCPv6 server not using DHCP Client Extensions,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#message-exchange-between-uefi-client-and-dhcpv6-server-not-using-dhcp-client-extensions
+24.7.9.3,Message exchange between UEFI Client and DNS6 server,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#message-exchange-between-uefi-client-and-dns6-server
+24.7.9.4,Message in HTTP Download,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#message-in-http-download-2
+24.7.10,Concept of Message Exchange in HTTP Boot scenario (with Proxy Host),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#concept-of-message-exchange-in-http-boot-scenario-with-proxy-host
+24.7.11,EFI HTTP Boot Callback Protocol,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-http-boot-callback-protocol
+24.7.12,EFI_HTTP_BOOT_CALLBACK_PROTOCOL,https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-http-boot-callback-protocol-1
+24.7.13,EFI_HTTP_BOOT_CALLBACK_PROTOCOL.Callback(),https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-http-boot-callback-protocol-callback
+25,Network Protocols - Managed Network,https://uefi.org/specs/UEFI/2.11/25_Network_Protocols_Managed_Network.html
+25.1,EFI Managed Network Protocol,https://uefi.org/specs/UEFI/2.11/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol
+25.1.1,EFI_MANAGED_NETWORK_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/25_Network_Protocols_Managed_Network.html#efi-managed-network-service-binding-protocol
+25.1.2,EFI_MANAGED_NETWORK_PROTOCOL,https://uefi.org/specs/UEFI/2.11/25_Network_Protocols_Managed_Network.html#id4
+25.1.3,EFI_MANAGED_NETWORK_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-getmodedata
+25.1.4,EFI_MANAGED_NETWORK_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-configure
+25.1.5,EFI_MANAGED_NETWORK_PROTOCOL.McastIpToMac(),https://uefi.org/specs/UEFI/2.11/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-mcastiptomac
+25.1.6,EFI_MANAGED_NETWORK_PROTOCOL.Groups(),https://uefi.org/specs/UEFI/2.11/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-groups
+25.1.7,EFI_MANAGED_NETWORK_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.11/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-transmit
+25.1.8,EFI_MANAGED_NETWORK_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.11/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-receive
+25.1.9,EFI_MANAGED_NETWORK_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.11/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-cancel
+25.1.10,EFI_MANAGED_NETWORK_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.11/25_Network_Protocols_Managed_Network.html#efi-managed-network-protocol-poll
+26,Network Protocols - Bluetooth,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html
+26.1,EFI Bluetooth Host Controller Protocol,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#efi-bluetooth-host-controller-protocol
+26.1.1,EFI_BLUETOOTH_HC_PROTOCOL,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#efi-bluetooth-hc-protocol
+26.1.2,BLUETOOTH_HC_PROTOCOL.SendCommand(),https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-sendcommand
+26.1.3,BLUETOOTH_HC_PROTOCOL.ReceiveEvent(),https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-receiveevent
+26.1.4,BLUETOOTH_HC_PROTOCOL.AsyncReceiveEvent(),https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-asyncreceiveevent
+26.1.5,BLUETOOTH_HC_PROTOCOL.SendACLData(),https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-sendacldata
+26.1.6,BLUETOOTH_HC_PROTOCOL.ReceiveACLData(),https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-receiveacldata
+26.1.7,BLUETOOTH_HC_PROTOCOL.AsyncReceiveACLData(),https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-asyncreceiveacldata
+26.1.8,BLUETOOTH_HC_PROTOCOL.SendSCOData(),https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-sendscodata
+26.1.9,BLUETOOTH_HC_PROTOCOL.ReceiveSCOData(),https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-receivescodata
+26.1.10,BLUETOOTH_HC_PROTOCOL.AsyncReceiveSCOData(),https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-hc-protocol-asyncreceivescodata
+26.2,EFI Bluetooth Bus Protocol,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#efi-bluetooth-bus-protocol
+26.2.1,EFI_BLUETOOTH_IO_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#efi-bluetooth-io-service-binding-protocol
+26.2.2,EFI_BLUETOOTH_IO_PROTOCOL,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#efi-bluetooth-io-protocol
+26.2.3,BLUETOOTH_IO_PROTOCOL.GetDeviceInfo,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-getdeviceinfo
+26.2.4,BLUETOOTH_IO_PROTOCOL.GetSdpInfo,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-getsdpinfo
+26.2.5,BLUETOOTH_IO_PROTOCOL.L2CapRawSend,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2caprawsend
+26.2.6,BLUETOOTH_IO_PROTOCOL.L2CapRawReceive,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2caprawreceive
+26.2.7,BLUETOOTH_IO_PROTOCOL.L2CapRawAsyncReceive,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2caprawasyncreceive
+26.2.8,BLUETOOTH_IO_PROTOCOL.L2CapSend,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2capsend
+26.2.9,BLUETOOTH_IO_PROTOCOL.L2CapReceive,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2capreceive
+26.2.10,BLUETOOTH_IO_PROTOCOL.L2CapAsyncReceive,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2capasyncreceive
+26.2.11,BLUETOOTH_IO_PROTOCOL.L2CapConnect,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2capconnect
+26.2.12,BLUETOOTH_IO_PROTOCOL.L2CapDisconnect,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2capdisconnect
+26.2.13,BLUETOOTH_IO_PROTOCOL.L2CapRegisterService,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-io-protocol-l2capregisterservice
+26.3,EFI Bluetooth Configuration Protocol,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#efi-bluetooth-configuration-protocol
+26.3.1,EFI_BLUETOOTH_CONFIG_PROTOCOL,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#efi-bluetooth-config-protocol
+26.3.2,BLUETOOTH_CONFIG_PROTOCOL.Init,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-init
+26.3.3,BLUETOOTH_CONFIG_PROTOCOL.Scan,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-scan
+26.3.4,BLUETOOTH_CONFIG_PROTOCOL.Connect,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-connect
+26.3.5,BLUETOOTH_CONFIG_PROTOCOL.Disconnect,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-disconnect
+26.3.6,BLUETOOTH_CONFIG_PROTOCOL.GetData,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-getdata
+26.3.7,BLUETOOTH_CONFIG_PROTOCOL.SetData,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-setdata
+26.3.8,BLUETOOTH_CONFIG_PROTOCOL.GetRemoteData,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-getremotedata
+26.3.9,BLUETOOTH_CONFIG_PROTOCOL.RegisterPinCallback,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-registerpincallback
+26.3.10,BLUETOOTH_CONFIG_PROTOCOL.RegisterGetLinkKeyCallback,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-registergetlinkkeycallback
+26.3.11,BLUETOOTH_CONFIG_PROTOCOL.RegisterSetLinkKeyCallback,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-registersetlinkkeycallback
+26.3.12,BLUETOOTH_CONFIG_PROTOCOL.RegisterLinkConnectCompleteCallback,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-config-protocol-registerlinkconnectcompletecallback
+26.4,EFI Bluetooth Attribute Protocol,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#efi-bluetooth-attribute-protocol
+26.4.1,EFI_BLUETOOTH_ATTRIBUTE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#id41
+26.4.2,BLUETOOTH_ATTRIBUTE_PROTOCOL.SendRequest,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-attribute-protocol-sendrequest
+26.4.3,BLUETOOTH_ATTRIBUTE_PROTOCOL.RegisterForServerNotification,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-attribute-protocol-registerforservernotification
+26.4.4,BLUETOOTH_ATTRIBUTE_PROTOCOL.GetServiceInfo,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-attribute-protocol-getserviceinfo
+26.4.5,BLUETOOTH_ATTRIBUTE_PROTOCOL.GetDeviceInfo,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-attribute-protocol-getdeviceinfo
+26.4.6,EFI_BLUETOOTH_ATTRIBUTE_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#efi-bluetooth-attribute-service-binding-protocol
+26.5,EFI Bluetooth LE Configuration Protocol,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#efi-bluetooth-le-configuration-protocol
+26.5.1,EFI_BLUETOOTH_LE_CONFIG_PROTOCOL,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#efi-bluetooth-le-config-protocol
+26.5.2,BLUETOOTH_LE_CONFIG_PROTOCOL.Init,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-init
+26.5.3,BLUETOOTH_LE_CONFIG_PROTOCOL.Scan,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-scan
+26.5.4,BLUETOOTH_LE_CONFIG_PROTOCOL.Connect,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-connect
+26.5.5,BLUETOOTH_LE_CONFIG_PROTOCOL.Disconnect,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-disconnect
+26.5.6,BLUETOOTH_LE_CONFIG_PROTOCOL.GetData,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-getdata
+26.5.7,BLUETOOTH_LE_CONFIG_PROTOCOL.SetData,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-setdata
+26.5.8,BLUETOOTH_LE_CONFIG_PROTOCOL.GetRemoteData,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-getremotedata
+26.5.9,BLUETOOTH_LE_CONFIG_PROTOCOL.RegisterSmpAuthCallback,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-registersmpauthcallback
+26.5.10,BLUETOOTH_LE_CONFIG_PROTOCOL.SendSmpAuthData,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-sendsmpauthdata
+26.5.11,BLUETOOTH_LE_CONFIG_PROTOCOL.RegisterSmpGetDataCallback,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-registersmpgetdatacallback
+26.5.12,BLUETOOTH_LE_CONFIG_PROTOCOL.RegisterSmpSetDataCallback,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-registersmpsetdatacallback
+26.5.13,BLUETOOTH_LE_CONFIG_PROTOCOL.RegisterLinkConnectCompleteCallback,https://uefi.org/specs/UEFI/2.11/26_Network_Protocols_Bluetooth.html#bluetooth-le-config-protocol-registerlinkconnectcompletecallback
+27,"Network Protocols - VLAN, EAP, Wi-Fi and Supplicant",https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html
+27.1,VLAN Configuration Protocol,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#vlan-configuration-protocol
+27.1.1,EFI_VLAN_CONFIG_PROTOCOL,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-vlan-config-protocol
+27.1.2,EFI_VLAN_CONFIG_PROTOCOL.Set(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-vlan-config-protocol-set
+27.1.3,EFI_VLAN_CONFIG_PROTOCOL.Find(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-vlan-config-protocol-find
+27.1.4,EFI_VLAN_CONFIG_PROTOCOL.Remove(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-vlan-config-protocol-remove
+27.2,EAP Protocol,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#eap-protocol
+27.2.1,EFI_EAP_PROTOCOL,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-protocol
+27.2.2,EFI_EAP.SetDesiredAuthMethod(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-setdesiredauthmethod
+27.2.3,EFI_EAP.RegisterAuthMethod(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-registerauthmethod
+27.2.4,EAPManagement Protocol,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#eapmanagement-protocol
+27.2.5,EFI_EAP_MANAGEMENT_PROTOCOL,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-protocol
+27.2.6,EFI_EAP_MANAGEMENT.GetSystemConfiguration(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-getsystemconfiguration
+27.2.7,EFI_EAP_MANAGEMENT.SetSystemConfiguration(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-setsystemconfiguration
+27.2.8,EFI_EAP_MANAGEMENT.InitializePort(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-initializeport
+27.2.9,EFI_EAP_MANAGEMENT.UserLogon(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-userlogon
+27.2.10,EFI_EAP_MANAGEMENT.UserLogoff(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-userlogoff
+27.2.11,EFI_EAP_MANAGEMENT.GetSupplicantStatus(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-getsupplicantstatus
+27.2.12,EFI_EAP_MANAGEMENT.SetSupplicantConfiguration(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-setsupplicantconfiguration
+27.2.13,EFI_EAP_MANAGEMENT.GetSupplicantStatistics(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management-getsupplicantstatistics
+27.2.14,EFI EAP Management2 Protocol,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management2-protocol
+27.2.14.1,EFI_EAP_MANAGEMENT2_PROTOCOL,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#id21
+27.2.15,EFI_EAP_MANAGEMENT2_PROTOCOL.GetKey(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-management2-protocol-getkey
+27.2.16,EFI EAP Configuration Protocol,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-configuration-protocol
+27.2.16.1,EFI_EAP_CONFIGURATION_PROTOCOL,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#id24
+27.2.17,EFI_EAP_CONFIGURATION_PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-configuration-protocol-setdata
+27.2.18,EFI_EAP_CONFIGURATION_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-eap-configuration-protocol-getdata
+27.3,EFI Wireless MAC Connection Protocol,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-protocol
+27.3.1,EFI_WIRELESS_MAC_CONNECTION_PROTOCOL,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#id28
+27.3.2,EFI_WIRELESS_MAC_CONNECTION_PROTOCOL.Scan(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-protocol-scan
+27.3.3,EFI_WIRELESS_MAC_CONNECTION_PROTOCOL.Associate(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-protocol-associate
+27.3.4,EFI_WIRELESS_MAC_CONNECTION_PROTOCOL.Disassociate(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-protocol-disassociate
+27.3.5,EFI_WIRELESS_MAC_CONNECTION_PROTOCOL.Authenticate(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-protocol-authenticate
+27.3.6,EFI_WIRELESS_MAC_CONNECTION_PROTOCOL.Deauthenticate(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-protocol-deauthenticate
+27.4,EFI Wireless MAC Connection II Protocol,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-ii-protocol
+27.4.1,EFI_WIRELESS_MAC_CONNECTION_II_PROTOCOL,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#id35
+27.4.2,EFI_WIRELESS_MAC_CONNECTION_II_PROTOCOL.GetNetworks(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-ii-protocol-getnetworks
+27.4.3,EFI_WIRELESS_MAC_CONNECTION_II_PROTOCOL.ConnectNetwork(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-ii-protocol-connectnetwork
+27.4.4,EFI_WIRELESS_MAC_CONNECTION_II_PROTOCOL.DisconnectNetwork(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-wireless-mac-connection-ii-protocol-disconnectnetwork
+27.5,EFI Supplicant Protocol,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-protocol
+27.5.1,Supplicant Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#supplicant-service-binding-protocol
+27.5.2,EFI_SUPPLICANT_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-service-binding-protocol
+27.5.3,Supplicant Protocol,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#supplicant-protocol
+27.5.4,EFI_SUPPLICANT_PROTOCOL,https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-protocol-network-protocols-vlan-and-eap
+27.5.5,EFI_SUPPLICANT_PROTOCOL.BuildResponsePacket(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-protocol-buildresponsepacket
+27.5.6,EFI_SUPPLICANT_PROTOCOL.ProcessPacket(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-protocol-processpacket
+27.5.7,EFI_SUPPLICANT_PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-protocol-setdata
+27.5.8,EFI_SUPPLICANT_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.11/27_Network_Protocols_VLAN_and_EAP.html#efi-supplicant-protocol-getdata
+28,"Network Protocols - TCP, IP, IPsec, FTP, TLS and Configurations",https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html
+28.1,EFI TCPv4 Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcpv4-protocol
+28.1.1,TCP4 Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#tcp4-service-binding-protocol
+28.1.2,EFI_TCP4_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-service-binding-protocol
+28.1.3,TCP4 Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#tcp4-protocol
+28.1.4,EFI_TCP4_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol
+28.1.5,EFI_TCP4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-getmodedata
+28.1.6,EFI_TCP4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-configure
+28.1.7,EFI_TCP4_PROTOCOL.Routes(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-routes
+28.1.8,EFI_TCP4_PROTOCOL.Connect(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-connect
+28.1.9,EFI_TCP4_PROTOCOL.Accept(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-accept
+28.1.10,EFI_TCP4_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-transmit
+28.1.10.1,EFI_TCP4_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-receive
+28.1.11,EFI_TCP4_PROTOCOL.Close(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-close
+28.1.12,EFI_TCP4_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-cancel
+28.1.13,EFI_TCP4_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp4-protocol-poll
+28.2,EFI TCPv6 Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcpv6-protocol
+28.2.1,TCPv6 Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#tcpv6-service-binding-protocol
+28.2.2,EFI_TCP6_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-service-binding-protocol
+28.2.3,TCPv6 Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#tcpv6-protocol
+28.2.4,EFI_TCP6_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol
+28.2.5,EFI_TCP6_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-getmodedata
+28.2.6,EFI_TCP6_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-configure
+28.2.7,EFI_TCP6_PROTOCOL.Connect(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-connect
+28.2.8,EFI_TCP6_PROTOCOL.Accept(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-accept
+28.2.9,EFI_TCP6_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-transmit
+28.2.10,EFI_TCP6_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-receive
+28.2.11,EFI_TCP6_PROTOCOL.Close(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-close
+28.2.12,EFI_TCP6_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-cancel
+28.2.13,EFI_TCP6_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tcp6-protocol-poll
+28.3,EFI IPv4 Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipv4-protocol
+28.3.1,IP4 Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#ip4-service-binding-protocol
+28.3.2,EFI_IP4_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-service-binding-protocol
+28.3.3,IP4 Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#ip4-protocol
+28.3.4,EFI_IP4_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol
+28.3.5,EFI_IP4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-getmodedata
+28.3.6,EFI_IP4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-configure
+28.3.7,EFI_IP4_PROTOCOL.Groups(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-groups
+28.3.8,EFI_IP4_PROTOCOL.Routes(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-routes
+28.3.9,EFI_IP4_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-transmit
+28.3.10,EFI_IP4_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-receive
+28.3.11,EFI_IP4_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-cancel
+28.3.12,EFI_IP4_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-protocol-poll
+28.4,EFI IPv4 Configuration II Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipv4-configuration-ii-protocol
+28.4.1,EFI_IP4_CONFIG2_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-config2-protocol
+28.4.2,EFI_IP4_CONFIG2_PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-config2-protocol-setdata
+28.4.3,EFI_IP4_CONFIG2_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-config2-protocol-getdata
+28.4.4,EFI_IP4_CONFIG2_PROTOCOL.RegisterDataNotify (),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-config2-protocol-registerdatanotify
+28.4.5,EFI_IP4_CONFIG2_PROTOCOL.UnregisterDataNotify (),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip4-config2-protocol-unregisterdatanotify
+28.5,EFI IPv6 Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipv6-protocol
+28.5.1,IPv6 Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#ipv6-service-binding-protocol
+28.5.2,EFI_IP6_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-service-binding-protocol
+28.5.3,IPv6 Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#ipv6-protocol
+28.5.4,EFI_IP6_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol
+28.5.5,EFI_IP6_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-getmodedata
+28.5.6,EFI_IP6_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-configure
+28.5.7,EFI_IP6_PROTOCOL.Groups(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-groups
+28.5.8,EFI_IP6_PROTOCOL.Routes(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-routes
+28.5.9,EFI_IP6_PROTOCOL.Neighbors(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-neighbors
+28.5.10,EFI_IP6_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-transmit
+28.5.11,EFI_IP6_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-receive
+28.5.12,EFI_IP6_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-cancel
+28.5.13,EFI_IP6_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-protocol-poll
+28.6,EFI IPv6 Configuration Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipv6-configuration-protocol
+28.6.1,EFI_IP6_CONFIG_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-config-protocol
+28.6.2,EFI_IP6_CONFIG_PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-config-protocol-setdata
+28.6.3,EFI_IP6_CONFIG_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-config-protocol-getdata
+28.6.4,EFI_IP6_CONFIG_PROTOCOL.RegisterDataNotify (),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-config-protocol-registerdatanotify
+28.6.5,EFI_IP6_CONFIG_PROTOCOL.UnregisterDataNotify(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ip6-config-protocol-unregisterdatanotify
+28.7,IPsec,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#ipsec
+28.7.1,IPsec Overview,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#ipsec-overview
+28.7.2,EFI IPsec Configuration Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-configuration-protocol
+28.7.3,EFI_IPSEC_CONFIG_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-config-protocol
+28.7.4,EFI_IPSEC_CONFIG_PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-config-protocol-setdata
+28.7.5,EFI_IPSEC_CONFIG_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-config-protocol-getdata
+28.7.6,EFI_IPSEC_CONFIG_PROTOCOL.GetNextSelector(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-config-protocol-getnextselector
+28.7.7,EFI_IPSEC_CONFIG_PROTOCOL.RegisterDataNotify (),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-config-protocol-registerdatanotify
+28.7.8,EFI_IPSEC_CONFIG_PROTOCOL.UnregisterDataNotify (),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-config-protocol-unregisterdatanotify
+28.7.9,EFI IPsec Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-protocol
+28.7.10,EFI_IPSEC_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#id79
+28.7.11,EFI_IPSEC_PROTOCOL.Process(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec-protocol-process
+28.7.12,EFI IPsec2 Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec2-protocol
+28.7.13,EFI_IPSEC2_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#id83
+28.7.14,EFI_IPSEC2_PROTOCOL.ProcessExt(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ipsec2-protocol-processext
+28.8,Network Protocol - EFI FTP Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#network-protocol-efi-ftp-protocol
+28.8.1,EFI_FTP4_SERVICE_BINDING_PROTOCOL Summary,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-service-binding-protocol-summary
+28.8.2,EFI_FTP4_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol
+28.8.3,EFI_FTP4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-getmodedata
+28.8.4,EFI_FTP4_PROTOCOL.Connect(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-connect
+28.8.5,EFI_FTP4_PROTOCOL.Close(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-close
+28.8.6,EFI_FTP4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-configure
+28.8.7,EFI_FTP4_PROTOCOL.ReadFile(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-readfile
+28.8.8,EFI_FTP4_PROTOCOL.WriteFile(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-writefile
+28.8.9,EFI_FTP4_PROTOCOL.ReadDirectory(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-readdirectory
+28.8.10,EFI_FTP4_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-ftp4-protocol-poll
+28.9,EFI TLS Protocols,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-protocols
+28.9.1,EFI TLS Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-service-binding-protocol
+28.9.1.1,EFI_TLS_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#id99
+28.9.2,EFI TLS Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-protocol
+28.9.2.1,EFI_TLS_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#id101
+28.9.3,EFI_TLS_PROTOCOL.SetSessionData (),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-protocol-setsessiondata
+28.9.4,EFI_TLS_PROTOCOL.GetSessionData (),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-protocol-getsessiondata
+28.9.5,EFI_TLS_PROTOCOL.BuildResponsePacket (),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-protocol-buildresponsepacket
+28.9.6,EFI_TLS_PROTOCOL.ProcessPacket (),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-protocol-processpacket
+28.9.7,EFI TLS Configuration Protocol,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-configuration-protocol
+28.9.7.1,EFI_TLS_CONFIGURATION_PROTOCOL,https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#id107
+28.9.8,EFI_TLS_CONFIGURATION_PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-configuration-protocol-setdata
+28.9.9,EFI_TLS_CONFIGURATION_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.11/28_Network_Protocols_TCP_IP_and_Configuration.html#efi-tls-configuration-protocol-getdata
+29,"Network Protocols - ARP, DHCP, DNS, HTTP and REST",https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html
+29.1,ARP Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#arp-protocol
+29.1.1,EFI_ARP_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-service-binding-protocol
+29.1.2,EFI_ARP_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol
+29.1.3,EFI_ARP_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-configure
+29.1.4,EFI_ARP_PROTOCOL.Add(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-add
+29.1.5,EFI_ARP_PROTOCOL.Find(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-find
+29.1.6,EFI_ARP_PROTOCOL.Delete(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-delete
+29.1.7,EFI_ARP_PROTOCOL.Flush(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-flush
+29.1.8,EFI_ARP_PROTOCOL.Request(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-request
+29.1.9,EFI_ARP_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-arp-protocol-cancel
+29.2,EFI DHCPv4 Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcpv4-protocol
+29.2.1,EFI_DHCP4_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-service-binding-protocol
+29.2.2,EFI_DHCP4_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol
+29.2.3,EFI_DHCP4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-getmodedata
+29.2.4,EFI_DHCP4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-configure
+29.2.5,EFI_DHCP4_PROTOCOL.Start(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-start
+29.2.6,EFI_DHCP4_PROTOCOL.RenewRebind(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-renewrebind
+29.2.7,EFI_DHCP4_PROTOCOL.Release(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-release
+29.2.8,EFI_DHCP4_PROTOCOL.Stop(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-stop
+29.2.9,EFI_DHCP4_PROTOCOL.Build(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-build
+29.2.10,EFI_DHCP4_PROTOCOL.TransmitReceive(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-transmitreceive
+29.2.11,EFI_DHCP4_PROTOCOL.Parse(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp4-protocol-parse
+29.3,EFI DHCP6 Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol
+29.3.1,DHCP6 Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#dhcp6-service-binding-protocol
+29.3.2,EFI_DHCP6_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-service-binding-protocol
+29.3.3,DHCP6 Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#dhcp6-protocol
+29.3.4,EFI_DHCP6_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#id27
+29.3.5,EFI_DHCP6_PROTOCOL.GetModeData (),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-getmodedata
+29.3.6,EFI_DHCP6_PROTOCOL.Configure (),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-configure
+29.3.7,EFI_DHCP6_PROTOCOL.Start (),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-start
+29.3.8,EFI_DHCP6_PROTOCOL.InfoRequest (),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-inforequest
+29.3.9,EFI_DHCP6_PROTOCOL.RenewRebind (),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-renewrebind
+29.3.10,EFI_DHCP6_PROTOCOL.Decline (),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-decline
+29.3.11,EFI_DHCP6_PROTOCOL.Release (),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-release
+29.3.12,EFI_DHCP6_PROTOCOL.Stop (),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-stop
+29.3.13,EFI_DHCP6_PROTOCOL.Parse (),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dhcp6-protocol-parse
+29.4,EFI DNSv4 Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dnsv4-protocol
+29.4.1,EFI_DNS4_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-service-binding-protocol
+29.4.2,EFI_DNS4_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol
+29.4.3,EFI_DNS4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-getmodedata
+29.4.4,EFI_DNS4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-configure
+29.4.5,EFI_DNS4_PROTOCOL.HostNameToIp(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-hostnametoip
+29.4.6,EFI_DNS4_PROTOCOL.IpToHostName(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-iptohostname
+29.4.7,EFI_DNS4_PROTOCOL.GeneralLookUp(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-generallookup
+29.4.8,EFI_DNS4_PROTOCOL.UpdateDnsCache(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-updatednscache
+29.4.9,EFI_DNS4_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-poll
+29.4.10,EFI_DNS4_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns4-protocol-cancel
+29.5,EFI DNSv6 Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dnsv6-protocol
+29.5.1,DNS6 Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#dns6-service-binding-protocol
+29.5.2,EFI_DNS6_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-service-binding-protocol
+29.5.3,DNS6 Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#dns6-protocol
+29.5.4,EFI_DNS6_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol
+29.5.5,EFI_DNS6_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-getmodedata
+29.5.6,EFI_DNS6_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-configure
+29.5.7,EFI_DNS6_PROTOCOL.HostNameToIp(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-hostnametoip
+29.5.8,EFI_DNS6_PROTOCOL.IpToHostName(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-iptohostname
+29.5.9,EFI_DNS6_PROTOCOL.GeneralLookUp(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-generallookup
+29.5.10,EFI_DNS6_PROTOCOL.UpdateDnsCache(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-updatednscache
+29.5.11,EFI_DNS6_PROTOCOL.POLL(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-poll
+29.5.12,EFI_DNS6_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-dns6-protocol-cancel
+29.6,EFI HTTP Protocols,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocols
+29.6.1,HTTP Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#http-service-binding-protocol
+29.6.1.1,EFI_HTTP_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-http-service-binding-protocol
+29.6.2,EFI HTTP Protocol Specific Definitions,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-specific-definitions
+29.6.3,EFI_HTTP_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol
+29.6.4,EFI_HTTP_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-getmodedata
+29.6.5,EFI_HTTP_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-configure
+29.6.6,EFI_HTTP_PROTOCOL.Request(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-request
+29.6.7,EFI_HTTP_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-cancel
+29.6.8,EFI_HTTP_PROTOCOL.Response(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-response
+29.6.9,EFI_HTTP_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-http-protocol-poll
+29.6.9.1,Usage Examples,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#usage-examples
+29.6.10,HTTP Utilities Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#http-utilities-protocol
+29.6.11,EFI_HTTP_UTILITIES_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-http-utilities-protocol
+29.6.12,EFI_HTTP_UTILITIES_PROTOCOL.Build(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-http-utilities-protocol-build
+29.6.13,EFI_HTTP_UTILITIES_PROTOCOL.Parse(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-http-utilities-protocol-parse
+29.7,EFI REST Support Overview,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-support-overview
+29.7.1,EFI REST Support Scenario 1 (PlatformManagement),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-support-scenario-1-platformmanagement
+29.7.2,EFI REST Support Scenario 2 (PlatformManagement),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-support-scenario-2-platformmanagement
+29.7.3,EFI REST Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-protocol
+29.7.3.1,EFI REST Protocol Definitions,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-protocol-definitions
+29.7.4,EFI_REST_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#id81
+29.7.5,EFI_REST_PROTOCOL.SendReceive(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-protocol-sendreceive
+29.7.6,EFI_REST_PROTOCOL.GetServiceTime(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-protocol-getservicetime
+29.7.7,EFI REST EX Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol
+29.7.7.1,REST EX Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#rest-ex-service-binding-protocol
+29.7.8,EFI_REST_EX_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-service-binding-protocol
+29.7.8.1,REST EX Protocol Specific Definitions,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#rest-ex-protocol-specific-definitions
+29.7.9,EFI_REST_EX_PROTOCOL,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#id88
+29.7.10,EFI_REST_EX_PROTOCOL.SendReceive(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol-sendreceive
+29.7.11,EFI_REST_EX_PROTOCOL.GetService(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol-getservice
+29.7.12,EFI_REST_EX_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol-getmodedata
+29.7.13,EFI_REST_EX_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol-configure
+29.7.14,EFI_REST_EX_PROTOCOL.AsyncSendReceive(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol-asyncsendreceive
+29.7.15,EFI_REST_EX_PROTOCOL.EventService(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-ex-protocol-eventservice
+29.7.15.1,Usage Example (HTTP-aware REST EX Protocol DriverInstance),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#usage-example-http-aware-rest-ex-protocol-driverinstance
+29.7.16,EFI_REST_EX_PROTOCOL.EventService(),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#id98
+29.7.17,EFI REST JSON Resource to C Structure Converter,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-json-resource-to-c-structure-converter
+29.7.17.1,Overview,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#overview
+29.7.17.2,EFI REST JSON Structure Protocol,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-json-structure-protocol
+29.7.18,EFI_REST_JSON_STRUCTURE.Register (),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-json-structure-register
+29.7.19,EFI_REST_JSON_STRUCTURE.ToStructure (),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-json-structure-tostructure
+29.7.20,EFI_REST_JSON_STRUCTURE.ToJson (),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-json-structure-tojson
+29.7.21,EFI_REST_JSON_STRUCTURE.DestroyStructure (),https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-rest-json-structure-destroystructure
+29.7.21.1,EFI Redfish JSON Structure Converter,https://uefi.org/specs/UEFI/2.11/29_Network_Protocols_ARP_and_DHCP.html#efi-redfish-json-structure-converter
+30,Network Protocols - UDP and MTFTP,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html
+30.1,EFI UDP Protocol,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp-protocol
+30.1.1,UDP4 Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#udp4-service-binding-protocol
+30.1.1.1,EFI_UDP4_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-service-binding-protocol
+30.1.2,UDP4 Protocol,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#udp4-protocol
+30.1.2.1,EFI_UDP4_PROTOCOL,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol
+30.1.2.2,EFI_UDP4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-getmodedata
+30.1.2.3,EFI_UDP4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-configure
+30.1.2.4,EFI_UDP4_PROTOCOL.Groups(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-groups
+30.1.2.5,EFI_UDP4_PROTOCOL.Routes(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-routes
+30.1.2.6,EFI_UDP4_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-transmit
+30.1.2.7,EFI_UDP4_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-receive
+30.1.2.8,EFI_UDP4_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-cancel
+30.1.2.9,EFI_UDP4_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp4-protocol-poll
+30.2,EFI UDPv6 Protocol,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udpv6-protocol
+30.2.1,UDP6 Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#udp6-service-binding-protocol
+30.2.1.1,EFI_UDP6_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-service-binding-protocol
+30.2.2,EFI UDP6 Protocol,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol
+30.2.2.1,EFI_UDP6_PROTOCOL,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#id18
+30.2.2.2,EFI_UDP6_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-getmodedata
+30.2.2.3,EFI_UDP6_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-configure
+30.2.2.4,EFI_UDP6_PROTOCOL.Groups(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-groups
+30.2.2.5,EFI_UDP6_PROTOCOL.Transmit(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-transmit
+30.2.2.6,EFI_UDP6_PROTOCOL.Receive(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-receive
+30.2.2.7,EFI_UDP6_PROTOCOL.Cancel(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-cancel
+30.2.2.8,EFI_UDP6_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-udp6-protocol-poll
+30.3,EFI MTFTPv4 Protocol,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftpv4-protocol
+30.3.1,EFI_MTFTP4_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-service-binding-protocol
+30.3.2,EFI_MTFTP4_PROTOCOL,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol
+30.3.3,EFI_MTFTP4_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-getmodedata
+30.3.4,EFI_MTFTP4_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-configure
+30.3.5,EFI_MTFTP4_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-getinfo
+30.3.6,EFI_MTFTP4_PROTOCOL.ParseOptions(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-parseoptions
+30.3.7,EFI_MTFTP4_PROTOCOL.ReadFile(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-readfile
+30.3.8,EFI_MTFTP4_PROTOCOL.WriteFile(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-writefile
+30.3.9,EFI_MTFTP4_PROTOCOL.ReadDirectory(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-readdirectory
+30.3.10,EFI_MTFTP4_PROTOCOL.POLL(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp4-protocol-poll
+30.4,EFI MTFTPv6 Protocol,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftpv6-protocol
+30.4.1,MTFTP6 Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#mtftp6-service-binding-protocol
+30.4.1.1,EFI_MTFTP6_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-service-binding-protocol
+30.4.2,MTFTP6 Protocol,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#mtftp6-protocol
+30.4.2.1,EFI_MTFTP6_PROTOCOL,https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol
+30.4.2.2,EFI_MTFTP6_PROTOCOL.GetModeData(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-getmodedata
+30.4.2.3,EFI_MTFTP6_PROTOCOL.Configure(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-configure
+30.4.2.4,EFI_MTFTP6_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-getinfo
+30.4.2.5,EFI_MTFTP6_PROTOCOL.ParseOptions(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-parseoptions
+30.4.2.6,EFI_MTFTP6_PROTOCOL.ReadFile(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-readfile
+30.4.2.7,EFI_MTFTP6_PROTOCOL.WriteFile(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-writefile
+30.4.2.8,EFI_MTFTP6_PROTOCOL.ReadDirectory(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-readdirectory
+30.4.2.9,EFI_MTFTP6_PROTOCOL.Poll(),https://uefi.org/specs/UEFI/2.11/30_Network_Protocols_UDP_and_MTFTP.html#efi-mtftp6-protocol-poll
+31,EFI Redfish Service Support,https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html
+31.1,EFI Redfish Discover Protocol,https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-protocol
+31.1.1,Overview,https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#overview
+31.1.2,EFI Redfish Discover Driver,https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-driver
+31.1.3,EFI Redfish Discover Client,https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-client
+31.1.4,EFI Redfish Discover Protocol,https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-protocol-1
+31.1.4.1,EFI_REDFISH_DISCOVER_PROTOCOL.GetNetworkInterfaceList(),https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-protocol-getnetworkinterfacelist
+31.1.4.2,EFI_REDFISH_DISCOVER_PROTOCOL.AcquireRedfishService(),https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-protocol-acquireredfishservice
+31.1.4.3,EFI_REDFISH_DISCOVER_PROTOCOL.AbortAcquireRedfishService(),https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-protocol-abortacquireredfishservice
+31.1.4.4,EFI_REDFISH_DISCOVER_PROTOCOL.ReleaseRedfishService(),https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#efi-redfish-discover-protocol-releaseredfishservice
+31.1.5,Implementation Examples,https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#implementation-examples
+31.1.5.1,Processes to Discover Redfish Services,https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#processes-to-discover-redfish-services
+31.1.5.2,Network Interface Configuration,https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#network-interface-configuration
+31.2,EFI Redfish JSON Structure Converter,https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#efi-redfish-json-structure-converter
+31.2.1,The Guidance of Writing EFI Redfish JSONStructure Converter,https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#the-guidance-of-writing-efi-redfish-jsonstructure-converter
+31.2.2,The Guidance of Using EFI Redfish JSON Structure Converter,https://uefi.org/specs/UEFI/2.11/31_EFI_Redfish_Service_Support.html#the-guidance-of-using-efi-redfish-json-structure-converter
+32,Secure Boot and Driver Signing,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html
+32.1,Secure Boot,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#secure-boot
+32.1.1,EFI_AUTHENTICATION_INFO_PROTOCOL,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#efi-authentication-info-protocol
+32.1.2,EFI_AUTHENTICATION_INFO_PROTOCOL.Get(),https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#efi-authentication-info-protocol-get
+32.1.3,EFI_AUTHENTICATION_INFO_PROTOCOL.Set(),https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#efi-authentication-info-protocol-set
+32.1.4,Authentication Nodes,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#authentication-nodes
+32.1.5,Generic Authentication Node Structures,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#generic-authentication-node-structures
+32.1.6,CHAP (using RADIUS) Authentication Node,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#chap-using-radius-authentication-node
+32.2,UEFI Driver Signing Overview,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#uefi-driver-signing-overview
+32.2.1,Digital Signatures,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#digital-signatures
+32.2.2,Embedded Signatures,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#embedded-signatures
+32.2.3,Creating Image Digests from Images,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#creating-image-digests-from-images
+32.2.4,Code Definitions,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#code-definitions
+32.2.4.1,WIN_CERTIFICATE,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#win-certificate
+32.2.4.2,WIN_CERTIFICATE_EFI_PKCS1_15,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#win-certificate-efi-pkcs1-15
+32.2.4.3,WIN_CERTIFICATE_UEFI_GUID,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#win-certificate-uefi-guid
+32.3,Firmware/OS Key Exchange: Creating Trust Relationships,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#firmware-os-key-exchange-creating-trust-relationships
+32.3.1,Enrolling The Platform Key,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#enrolling-the-platform-key
+32.3.2,Clearing The Platform Key,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#clearing-the-platform-key
+32.3.3,Transitioning to Audit Mode,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#transitioning-to-audit-mode
+32.3.4,Transitioning to Deployed Mode,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#transitioning-to-deployed-mode
+32.3.5,Enrolling Key Exchange Keys,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#enrolling-key-exchange-keys
+32.3.6,Platform Firmware Key Storage Requirements,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#platform-firmware-key-storage-requirements
+32.4,Firmware/OS Key Exchange: Passing Public Keys,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#firmware-os-key-exchange-passing-public-keys
+32.4.1,Signature Database,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#signature-database
+32.4.1.1,EFI_SIGNATURE_DATA,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#efi-signature-data
+32.4.2,Image Execution Information Table,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#image-execution-information-table
+32.5,UEFI Image Validation,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#uefi-image-validation
+32.5.1,Overview,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#overview
+32.5.2,Authorized User,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#authorized-user
+32.5.3,Signature Database Update,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#signature-database-update
+32.5.3.1,Using The Image Execution Information Table,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#using-the-image-execution-information-table
+32.5.3.2,Firmware Policy,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#firmware-policy
+32.5.3.3,Authorization Process,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#authorization-process
+32.6,Device Authentication,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#device-authentication
+32.6.1,Overview,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#device-authentication-overview
+32.6.2,Authorized User,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#device-authentication-authorized-user
+32.6.3,Device Signature Database Update,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#device-signature-database-update
+32.7,Code Definitions,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#secure-boot-and-driver-signing-code-definitions
+32.7.1,UEFI Image Variable GUID & Variable Name,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#uefi-image-variable-guid-variable-name
+32.7.2,UEFI Device Signature Variable GUID and Variable Name,https://uefi.org/specs/UEFI/2.11/32_Secure_Boot_and_Driver_Signing.html#uefi-device-signature-variable-guid-and-variable-name
+33,Human Interface Infrastructure Overview,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html
+33.1,Goals,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#goals
+33.2,Design Discussion,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#design-discussion
+33.2.1,Drivers And Applications,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#drivers-and-applications
+33.2.1.1,Platform and Driver Configuration,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#platform-and-driver-configuration
+33.2.1.2,Pre-O/S applications,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#pre-o-s-applications
+33.2.1.3,Description of User Interface Components,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#description-of-user-interface-components
+33.2.1.4,Forms,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#forms
+33.2.1.5,Strings,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#strings
+33.2.1.6,Images/Fonts,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#images-fonts
+33.2.1.7,Consumers of the user interface data,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#consumers-of-the-user-interface-data
+33.2.1.8,Connected forms browser/processor,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#connected-forms-browser-processor
+33.2.1.9,Disconnected Forms Browser/Processor,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#disconnected-forms-browser-processor
+33.2.1.10,O/S-Present Forms Browser/Processor,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#o-s-present-forms-browser-processor
+33.2.1.11,Where are the Results Stored,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#where-are-the-results-stored
+33.2.2,Localization,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#localization
+33.2.3,User Input,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#user-input
+33.2.4,Keyboard Layout,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#keyboard-layout
+33.2.4.1,Keyboard Mapping,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#keyboard-mapping
+33.2.4.2,Modifier Keys,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#modifier-keys
+33.2.4.3,Non-Spacing Keys,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#non-spacing-keys
+33.2.5,Forms,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#forms-1
+33.2.5.1,Form Sets,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#form-sets
+33.2.5.2,Forms,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#forms-2
+33.2.5.3,Statements,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#statements
+33.2.5.4,Questions,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#questions
+33.2.5.5,Options,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#options
+33.2.5.6,Storage,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#storage
+33.2.5.7,Expressions,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#expressions
+33.2.5.8,Defaults,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#defaults
+33.2.5.9,Validation,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#validation
+33.2.5.10,Forms Processing,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#forms-processing
+33.2.5.11,Forms Editing,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#forms-editing
+33.2.5.12,Forms Processing & Security Privileges,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#forms-processing-security-privileges
+33.2.6,Strings,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#strings-1
+33.2.6.1,Configuration Language Paradigm,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#configuration-language-paradigm
+33.2.6.2,Unicode Usage,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#unicode-usage
+33.2.7,Fonts,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#fonts
+33.2.7.1,Font Attributes,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#font-attributes
+33.2.7.2,Limiting Glyphs,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#limiting-glyphs
+33.2.7.3,Fixed Font Description,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#fixed-font-description
+33.2.7.4,Proportional Fonts Description,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#proportional-fonts-description
+33.2.8,Images,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#images
+33.2.8.1,Converting to a 32-bit Display,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#converting-to-a-32-bit-display
+33.2.8.2,Non-TrueColor Displays,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#non-truecolor-displays
+33.2.9,HII Database,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#hii-database
+33.2.10,Forms Browser,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#forms-browser
+33.2.10.1,User Interaction,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#user-interaction
+33.2.11,Configuration Settings,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#configuration-settings
+33.2.11.1,OS Runtime Utilization,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#os-runtime-utilization
+33.2.11.2,Working with a UEFI Configuration Language,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#working-with-a-uefi-configuration-language
+33.2.12,Form Callback Logic,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#form-callback-logic
+33.2.13,Driver Model Interaction,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#driver-model-interaction
+33.2.14,Human Interface Component Interactions,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#human-interface-component-interactions
+33.2.15,Standards Map Forms,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#standards-map-forms
+33.2.15.1,Create A Question-s Value By Combing MultipleConfiguration Settings,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#create-a-questions-value-by-combing-multipleconfiguration-settings
+33.2.15.2,Changing Multiple Configuration Settings From One Question-s Value,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#changing-multiple-configuration-settings-from-one-questions-value
+33.2.15.3,Value Shifting,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#value-shifting
+33.2.15.4,Prompts,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#prompts
+33.3,Code Definitions,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#code-definitions
+33.3.1,Package Lists and Package Headers,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#package-lists-and-package-headers
+33.3.1.1,EFI_HII_PACKAGE_HEADER,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#efi-hii-package-header
+33.3.1.2,EFI_HII_PACKAGE_LIST_HEADER,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#efi-hii-package-list-header
+33.3.2,Simplified Font Package,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#simplified-font-package
+33.3.2.1,EFI_HII_SIMPLE_FONT_PACKAGE_HDR,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#efi-hii-simple-font-package-hdr
+33.3.2.2,EFI_NARROW_GLYPH,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#efi-narrow-glyph
+33.3.2.3,EFI_WIDE_GLYPH,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#efi-wide-glyph
+33.3.3,Font Package,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#font-package
+33.3.3.1,Fixed Header,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#fixed-header
+33.3.3.2,Glyph Information,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#glyph-information
+33.3.4,Device Path Package,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#device-path-package
+33.3.5,GUID Package,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#guid-package
+33.3.6,String Package,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#string-package
+33.3.6.1,Fixed Header,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#fixed-header-1
+33.3.6.2,String Information,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#string-information
+33.3.6.3,String Encoding,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#string-encoding
+33.3.7,Image Package,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#image-package
+33.3.7.1,Fixed Header,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#fixed-header-2
+33.3.7.2,Image Information,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#image-information
+33.3.7.3,Palette Information,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#palette-information
+33.3.8,Forms Package,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#forms-package
+33.3.8.1,Binary Encoding,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#binary-encoding
+33.3.8.2,Standard Headers,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#standard-headers
+33.3.8.3,Opcode Reference,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#opcode-reference
+33.3.9,Keyboard Package,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#keyboard-package
+33.3.10,Animations Package,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#animations-package
+33.3.10.1,Animated Images Package,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#animated-images-package
+33.3.10.2,Animation Information,https://uefi.org/specs/UEFI/2.11/33_Human_Interface_Infrastructure.html#animation-information
+34,HII Protocols,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html
+34.1,Font Protocol,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#font-protocol
+34.1.1,EFI_HII_FONT_PROTOCOL,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-protocol
+34.1.2,EFI_HII_FONT_PROTOCOL.StringToImage(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-protocol-stringtoimage
+34.1.3,EFI_HII_FONT_PROTOCOL.StringIdToImage(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-protocol-stringidtoimage
+34.1.4,EFI_HII_FONT_PROTOCOL.GetGlyph(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-protocol-getglyph
+34.1.5,EFI_HII_FONT_PROTOCOL.GetFontInfo(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-protocol-getfontinfo
+34.2,EFI HII Font Ex Protocol,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-ex-protocol
+34.2.1,EFI_HII_FONT_EX_PROTOCOL,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-ex-protocol-1
+34.2.2,EFI_HII_FONT_EX_PROTOCOL.StringToImageEx(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-ex-protocol-stringtoimageex
+34.2.3,EFI_HII_FONT_EX_PROTOCOL.StringIdToImageEx(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-ex-protocol-stringidtoimageex
+34.2.4,EFI_HII_FONT_EX_PROTOCOL.GetGlyphEx(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-ex-protocol-getglyphex
+34.2.5,EFI_HII_FONT_EX_PROTOCOL.GetFontInfoEx(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-ex-protocol-getfontinfoex
+34.2.6,EFI_HII_FONT_EX_PROTOCOL.GetGlyphInfo(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-ex-protocol-getglyphinfo
+34.2.7,Code Definitions,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#code-definitions
+34.2.7.1,EFI_FONT_DISPLAY_INFO,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-font-display-info
+34.2.7.2,EFI_IMAGE_OUTPUT,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-image-output
+34.3,String Protocol,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#string-protocol
+34.3.1,EFI_HII_STRING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-string-protocol
+34.3.2,EFI_HII_STRING_PROTOCOL.NewString(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-string-protocol-newstring
+34.3.3,EFI_HII_STRING_PROTOCOL.GetString(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-string-protocol-getstring
+34.3.4,EFI_HII_STRING_PROTOCOL.SetString(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-string-protocol-setstring
+34.3.5,EFI_HII_STRING_PROTOCOL.GetLanguages(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-string-protocol-getlanguages
+34.3.6,EFI_HII_STRING_PROTOCOL.GetSecondaryLanguages(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-string-protocol-getsecondarylanguages
+34.4,Image Protocol,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#image-protocol
+34.4.1,EFI_HII_IMAGE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-protocol
+34.4.2,EFI_HII_IMAGE_PROTOCOL.NewImage(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-protocol-newimage
+34.4.3,EFI_HII_IMAGE_PROTOCOL.GetImage(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-protocol-getimage
+34.4.4,EFI_HII_IMAGE_PROTOCOL.SetImage(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-protocol-setimage
+34.4.5,EFI_HII_IMAGE_PROTOCOL.DrawImage(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-protocol-drawimage
+34.4.6,EFI_HII_IMAGE_PROTOCOL.DrawImageId(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-protocol-drawimageid
+34.5,EFI HII Image Ex Protocol,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-ex-protocol
+34.5.1,EFI_HII_IMAGE_EX_PROTOCOL,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-ex-protoco-1
+34.5.2,EFI_HII_IMAGE_EX_PROTOCOL.NewImageEx(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-ex-protocol-newimageex
+34.5.3,EFI_HII_IMAGE_EX_PROTOCOL.GetImageEx(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-ex-protocol-getimageex
+34.5.4,EFI_HII_IMAGE_EX_PROTOCOL.SetImageEx(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-ex-protocol-setimageex
+34.5.5,EFI_HII_IMAGE_EX_PROTOCOL.DrawImageEx(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-ex-protocol-drawimageex
+34.5.6,EFI_HII_IMAGE_EX_PROTOCOL.DrawImageIdEx(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-ex-protocol-drawimageidex
+34.5.7,EFI_HII_IMAGE_EX_PROTOCOL.GetImageInfo(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-ex-protocol-getimageinfo
+34.6,EFI HII Image Decoder Protocol,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-decoder-protocol
+34.6.1,EFI_HII_IMAGE_DECODER_PROTOCOL.DecodeImage(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-decoder-protocol-decodeimage
+34.6.2,EFI_HII_IMAGE_DECODER_PROTOCOL.GetImageDecoderName(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-decoder-protocol-getimagedecodername
+34.6.3,EFI_HII_IMAGE_DECODER_PROTOCOL.GetImageInfo(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-decoder-protocol-getimageinfo
+34.6.4,EFI_HII_IMAGE_DECODER_PROTOCOL.Decode(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-image-decoder-protocol-decode
+34.7,Font Glyph Generator Protocol,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#font-glyph-generator-protocol
+34.7.1,EFI_HII_FONT_GLYPH_GENERATOR_PROTOCOL,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-glyph-generator-protocol
+34.7.2,EFI_HII_FONT_GLYPH_GENERATOR_PROTOCOL.GenerateGlyph(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-glyph-generator-protocol-generateglyph
+34.7.3,EFI_HII_FONT_GLYPH_GENERATOR_PROTOCOL.GenerateGlyphImage(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-font-glyph-generator-protocol-generateglyphimage
+34.8,Database Protocol,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#database-protocol
+34.8.1,EFI_HII_DATABASE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-protocol
+34.8.2,EFI_HII_DATABASE_PROTOCOL.NewPackageList(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-protocol-newpackagelist
+34.8.3,EFI_HII_DATABASE_PROTOCOL.RemovePackageList(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-protocol-removepackagelist
+34.8.4,EFI_HII_DATABASE_PROTOCOL.UpdatePackageList(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-protocol-updatepackagelist
+34.8.5,EFI_HII_DATABASE_PROTOCOL.ListPackageLists(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-protocol-listpackagelists
+34.8.6,EFI_HII_DATABASE_PROTOCOL.ExportPackageLists(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-protocol-exportpackagelists
+34.8.7,EFI_HII_DATABASE_PROTOCOL.RegisterPackageNotify(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-protocol-registerpackagenotify
+34.8.8,EFI_HII_DATABASE_PROTOCOL.UnregisterPackageNotify(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-protocol-unregisterpackagenotify
+34.8.9,EFI_HII_DATABASE_PROTOCOL.FindKeyboardLayouts(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-protocol-findkeyboardlayouts
+34.8.10,EFI_HII_DATABASE_PROTOCOL.GetKeyboardLayout(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-protocol-getkeyboardlayout
+34.8.11,EFI_HII_DATABASE_PROTOCOL.SetKeyboardLayout(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-protocol-setkeyboardlayout
+34.8.12,EFI_HII_DATABASE_PROTOCOL.GetPackageListHandle(),https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-protocol-getpackagelisthandle
+34.8.13,Database Structures,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#database-structures
+34.8.13.1,EFI_HII_DATABASE_NOTIFY,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-notify
+34.8.14,EFI_HII_DATABASE_NOTIFY_TYPE,https://uefi.org/specs/UEFI/2.11/34_HII_Protocols.html#efi-hii-database-notify-type
+35,HII Configuration Processing and Browser Protocol,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html
+35.1,Introduction,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#introduction
+35.1.1,Common Configuration Data Format,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#common-configuration-data-format
+35.1.2,Data Flow,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#data-flow
+35.2,Configuration Strings,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#configuration-strings
+35.2.1,String Syntax,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#string-syntax
+35.2.1.1,Basic forms,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#basic-forms
+35.2.1.2,Types,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#types
+35.2.1.3,Routing elements,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#routing-elements
+35.2.1.4,Body elements,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#body-elements
+35.2.1.5,Configuration strings,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#configuration-strings-1
+35.2.1.6,Keyword strings,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#keyword-strings
+35.2.2,String Types,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#string-types
+35.3,EFI Configuration Keyword Handler Protocol,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-configuration-keyword-handler-protocol
+35.3.1,EFI_CONFIG_KEYWORD_HANDLER_PROTOCOL,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-config-keyword-handler-protocol
+35.3.2,EFI_KEYWORD_HANDLER _PROTOCOL.SetData(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-keyword-handler-protocol-setdata
+35.3.3,EFI_KEYWORD_HANDLER _PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-keyword-handler-protocol-getdata
+35.4,EFI HII Configuration Routing Protocol,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-configuration-routing-protocol
+35.4.1,EFI_HII_CONFIG_ROUTING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol
+35.4.2,EFI_HII_CONFIG_ROUTING_PROTOCOL.ExtractConfig(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol-extractconfig
+35.4.3,EFI_HII_CONFIG_ROUTING_PROTOCOL.ExportConfig(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol-exportconfig
+35.4.4,EFI_HII_CONFIG_ROUTING_PROTOCOL.RouteConfig(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol-routeconfig
+35.4.5,EFI_HII_CONFIG_ROUTING_PROTOCOL.BlockToConfig(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol-blocktoconfig
+35.4.6,EFI_HII_CONFIG_ROUTING_PROTOCOL.ConfigToBlock(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol-configtoblock
+35.4.7,EFI_HII_CONFIG_ROUTING_PROTOCOL.GetAltCfg(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-routing-protocol-getaltcfg
+35.5,EFI HII Configuration Access Protocol,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-configuration-access-protocol
+35.5.1,EFI_HII_CONFIG_ACCESS_PROTOCOL,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-access-protocol
+35.5.2,EFI_HII_CONFIG_ACCESS_PROTOCOL.ExtractConfig(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-access-protocol-extractconfig
+35.5.3,EFI_HII_CONFIG_ACCESS_PROTOCOL.RouteConfig(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-access-protocol-routeconfig
+35.5.4,EFI_HII_CONFIG_ACCESS_PROTOCOL.CallBack(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-config-access-protocol-callback
+35.6,Form Browser Protocol,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#form-browser-protocol
+35.6.1,EFI_FORM_BROWSER2_PROTOCOL,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-form-browser2-protocol
+35.6.2,EFI_FORM_BROWSER2_PROTOCOL.SendForm(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-form-browser2-protocol-sendform
+35.6.3,EFI_FORM_BROWSER2_PROTOCOL.BrowserCallback(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-form-browser2-protocol-browsercallback
+35.7,HII Popup Protocol,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#hii-popup-protocol
+35.7.1,EFI_HII_POPUP_PROTOCOL,https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-popup-protocol
+35.7.2,EFI_HII_POPUP_PROTOCOL.CreatePopup(),https://uefi.org/specs/UEFI/2.11/35_HII_Configuration_Processing_and_Browser_Protocol.html#efi-hii-popup-protocol-createpopup
+36,User Identification,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html
+36.1,User Identification Overview,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#user-identification-overview
+36.1.1,User Identify,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#user-identify
+36.1.2,User Profiles,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#user-profiles
+36.1.2.1,User Profile Database,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#user-profile-database
+36.1.2.2,User Identification Policy,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#user-identification-policy
+36.1.3,Credential Providers,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#credential-providers
+36.1.4,Security Considerations,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#security-considerations
+36.1.5,Deferred Execution,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#deferred-execution
+36.2,User Identification Process,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#user-identification-process
+36.2.1,User Identification Process,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#user-identification-process-1
+36.2.2,Changing The Current User Profile,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#changing-the-current-user-profile
+36.2.3,Ready To Boot,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#ready-to-boot
+36.3,Code Definitions,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#code-definitions
+36.3.1,User Manager Protocol,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#user-manager-protocol
+36.3.1.1,EFI_USER_MANAGER_PROTOCOL,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-manager-protocol
+36.3.1.2,EFI_USER_MANAGER_PROTOCOL.Create(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-manager-protocol-create
+36.3.1.3,EFI_USER_MANAGER_PROTOCOL.Delete(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-manager-protocol-delete
+36.3.1.4,EFI_USER_MANAGER_PROTOCOL.GetNext(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-manager-protocol-getnext
+36.3.1.5,EFI_USER_MANAGER_PROTOCOL.Current(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-manager-protocol-current
+36.3.1.6,EFI_USER_MANAGER_PROTOCOL.Identify(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-manager-protocol-identify
+36.3.1.7,EFI_USER_MANAGER_PROTOCOL.Find(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-manager-protocol-find
+36.3.1.8,EFI_USER_MANAGER_PROTOCOL.Notify(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-manager-protocol-notify
+36.3.1.9,EFI_USER_MANAGER_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-manager-protocol-getinfo
+36.3.1.10,EFI_USER_MANAGER_PROTOCOL.SetInfo(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-manager-protocol-setinfo
+36.3.1.11,EFI_USER_MANAGER_PROTOCOL.DeleteInfo(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-manager-protocol-deleteinfo
+36.3.1.12,EFI_USER_MANAGER_PROTOCOL.GetNextInfo(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-manager-protocol-getnextinfo
+36.3.2,Credential Provider Protocols,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#credential-provider-protocols
+36.3.2.1,EFI_USER_CREDENTIAL2_PROTOCOL,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-credential2-protocol
+36.3.2.2,EFI_USER_CREDENTIAL2_PROTOCOL.Enroll(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-credential2-protocol-enroll
+36.3.2.3,EFI_USER_CREDENTIAL2_PROTOCOL.Form(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-credential2-protocol-form
+36.3.2.4,EFI_USER_CREDENTIAL2_PROTOCOL.Tile(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-credential2-protocol-tile
+36.3.2.5,EFI_USER_CREDENTIAL2_PROTOCOL.Title(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-credential2-protocol-title
+36.3.2.6,EFI_USER_CREDENTIAL2_PROTOCOL.User(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-credential2-protocol-user
+36.3.2.7,EFI_USER_CREDENTIAL2_PROTOCOL.Select(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-credential2-protocol-select
+36.3.2.8,EFI_USER_CREDENTIAL2_PROTOCOL.Deselect(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-credential2-protocol-deselect
+36.3.2.9,EFI_USER_CREDENTIAL2_PROTOCOL.Default(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-credential2-protocol-default
+36.3.2.10,EFI_USER_CREDENTIAL2_PROTOCOL.GetInfo(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-credential2-protocol-getinfo
+36.3.2.11,EFI_USER_CREDENTIAL2_PROTOCOL.GetNextInfo(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-credential2-protocol-getnextinfo
+36.3.2.12,EFI_USER_CREDENTIAL2_PROTOCOL.Delete(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-credential2-protocol-delete
+36.3.3,Deferred Image Load Protocol,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#deferred-image-load-protocol
+36.3.3.1,EFI_DEFERRED_IMAGE_LOAD_PROTOCOL,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-deferred-image-load-protocol
+36.3.3.2,EFI_DEFERRED_IMAGE_LOAD_PROTOCOL.GetImageInfo(),https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-deferred-image-load-protocol-getimageinfo
+36.4,User Information,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#user-information
+36.4.1,EFI_USER_INFO_ACCESS_POLICY_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-access-policy-record
+36.4.1.1,EFI_USER_INFO_ACCESS_FORBID_LOAD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-access-forbid-load
+36.4.1.2,EFI_USER_INFO_ACCESS_PERMIT_LOAD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-access-permit-load
+36.4.1.3,EFI_USER_INFO_ACCESS_ENROLL_SELF,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-access-enroll-self
+36.4.1.4,EFI_USER_INFO_ACCESS_ENROLL_OTHERS,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-access-enroll-others
+36.4.1.5,EFI_USER_INFO_ACCESS_MANAGE,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-access-manage
+36.4.1.6,EFI_USER_INFO_ACCESS_SETUP,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-access-setup
+36.4.1.7,EFI_USER_INFO_ACCESS_FORBID_CONNECT,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-access-forbid-connect
+36.4.1.8,EFI_USER_INFO_ACCESS_PERMIT_CONNECT,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-access-permit-connect
+36.4.1.9,EFI_USER_INFO_ACCESS_BOOT_ORDER,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-access-boot-order
+36.4.2,EFI_USER_INFO_CBEFF_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-cbeff-record
+36.4.3,EFI_USER_INFO_CREATE_DATE_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-create-date-record
+36.4.4,EFI_USER_INFO_CREDENTIAL_PROVIDER_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-credential-provider-record
+36.4.5,EFI_USER_INFO_CREDENTIAL_PROVIDER_NAME_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-credential-provider-name-record
+36.4.6,EFI_USER_INFO_CREDENTIAL_TYPE_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-credential-type-record
+36.4.7,EFI_USER_INFO_CREDENTIAL_TYPE_NAME_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-credential-type-name-record
+36.4.8,EFI_USER_INFO_GUID_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-guid-record
+36.4.9,EFI_USER_INFO_FAR_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-far-record
+36.4.10,EFI_USER_INFO_IDENTIFIER_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-identifier-record
+36.4.11,EFI_USER_INFO_IDENTITY_POLICY_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-identity-policy-record
+36.4.12,EFI_USER_INFO_NAME_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-name-record
+36.4.13,EFI_USER_INFO_PKCS11_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-pkcs11-record
+36.4.14,EFI_USER_INFO_RETRY_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-retry-record
+36.4.15,EFI_USER_INFO_USAGE_DATE_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-usage-date-record
+36.4.16,EFI_USER_INFO_USAGE_COUNT_RECORD,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#efi-user-info-usage-count-record
+36.5,User Information Table,https://uefi.org/specs/UEFI/2.11/36_User_Identification.html#user-information-table
+37,Secure Technologies,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html
+37.1,Hash Overview,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#hash-overview
+37.1.1,Hash References,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#hash-references
+37.1.1.1,EFI_HASH_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-hash-service-binding-protocol
+37.1.1.2,EFI_HASH_PROTOCOL,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-hash-protocol
+37.1.1.3,EFI_HASH_PROTOCOL.GetHashSize(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-hash-protocol-gethashsize
+37.1.1.4,EFI_HASH_PROTOCOL.Hash(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-hash-protocol-hash
+37.1.2,Other Code Definitions,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#other-code-definitions
+37.1.2.1,"EFI_SHA1_HASH, EFI_SHA224_HASH, EFI_SHA256_HASH,EFI_SHA384_HASH, EFI_SHA512HASH, EFI_MD5_HASH",https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-sha1-hash-efi-sha224-hash-efi-sha256-hash-efi-sha384-hash-efi-sha512hash-efi-md5-hash
+37.1.2.2,EFI Hash Algorithms,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-hash-algorithms
+37.2,Hash2 Protocols,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#hash2-protocols
+37.2.1,EFI Hash2 Service Binding Protocol,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-hash2-service-binding-protocol
+37.2.1.1,EFI_HASH2_SERVICE_BINDING_PROTOCOL,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#id13
+37.2.2,EFI Hash2 Protocol,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-hash2-protocol
+37.2.2.1,EFI_HASH2_PROTOCOL,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#id15
+37.2.2.2,EFI_HASH2_PROTOCOL.GetHashSize(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-hash2-protocol-gethashsize
+37.2.2.3,EFI_HASH2_PROTOCOL.Hash(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-hash2-protocol-hash
+37.2.2.4,EFI_HASH2_PROTOCOL.HashInit(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-hash2-protocol-hashinit
+37.2.2.5,EFI_HASH2_PROTOCOL.HashUpdate(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-hash2-protocol-hashupdate
+37.2.2.6,EFI_HASH2_PROTOCOL.HashFinal(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-hash2-protocol-hashfinal
+37.2.3,Other Code Definitions,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#other-code-definitions-1
+37.2.3.1,EFI_HASH2_OUTPUT,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-hash2-output
+37.3,Key Management Service,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#key-management-service
+37.3.1,EFI_KEY_MANAGEMENT_SERVICE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-key-management-service-protocol
+37.3.2,EFI_KMS_PROTOCOL.GetServiceStatus(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-kms-protocol-getservicestatus
+37.3.2.1,EFI_KMS_PROTOCOL.RegisterClient(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-kms-protocol-registerclient
+37.3.2.2,EFI_KMS_PROTOCOL.CreateKey(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-kms-protocol-createkey
+37.3.2.3,EFI_KMS_PROTOCOL.GetKey(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-kms-protocol-getkey
+37.3.2.4,EFI_KMS_PROTOCOL.AddKey(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-kms-protocol-addkey
+37.3.2.5,EFI_KMS_PROTOCOL.DeleteKey(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-kms-protocol-deletekey
+37.3.2.6,EFI_KMS_PROTOCOL.GetKeyAttributes(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-kms-protocol-getkeyattributes
+37.3.2.7,EFI_KMS_PROTOCOL.AddKeyAttributes(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-kms-protocol-addkeyattributes
+37.3.2.8,EFI_KMS_PROTOCOL.DeleteKeyAttributes(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-kms-protocol-deletekeyattributes
+37.3.2.9,EFI_KMS_PROTOCOL.GetKeyByAttributes(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-kms-protocol-getkeybyattributes
+37.4,PKCS7 Verify Protocol,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#pkcs7-verify-protocol
+37.4.1,EFI_PKCS7_VERIFY_PROTOCOL,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-pkcs7-verify-protocol
+37.4.2,EFI_PKCS7_VERIFY_PROTOCOL.VerifyBuffer(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-pkcs7-verify-protocol-verifybuffer
+37.4.2.1,EFI_PKCS7_VERIFY_PROTOCOL.VerifySignature(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-pkcs7-verify-protocol-verifysignature
+37.5,Random Number Generator Protocol,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#random-number-generator-protocol
+37.5.1,EFI_RNG_PROTOCOL,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-rng-protocol
+37.5.2,EFI_RNG_PROTOCOL.GetInfo,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-rng-protocol-getinfo
+37.5.3,EFI_RNG_PROTOCOL.GetRNG,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-rng-protocol-getrng
+37.5.4,EFI RNG Algorithm Definitions,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-rng-algorithm-definitions
+37.5.5,RNG References,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#rng-references
+37.6,Smart Card Reader and Smart Card Edge Protocol,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#smart-card-reader-and-smart-card-edge-protocol
+37.6.1,Smart Card Reader Protocol,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#smart-card-reader-protocol
+37.6.1.1,EFI_SMART_CARD_READER_PROTOCOL Summary,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-reader-protocol-summary
+37.6.2,EFI_SMART_CARD_READER_PROTOCOL.SCardConnect(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-reader-protocol-scardconnect
+37.6.3,EFI_SMART_CARD_READER_PROTOCOL.SCardDisconnect(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-reader-protocol-scarddisconnect
+37.6.4,EFI_SMART_CARD_READER_PROTOCOL.SCardStatus(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-reader-protocol-scardstatus
+37.6.5,EFI_SMART_CARD_READER_PROTOCOL.SCardTransmit(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-reader-protocol-scardtransmit
+37.6.6,EFI_SMART_CARD_READER_PROTOCOL.SCardControl(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-reader-protocol-scardcontrol
+37.6.7,EFI_SMART_CARD_READER_PROTOCOL.SCardGetAttrib(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-reader-protocol-scardgetattrib
+37.6.8,Smart Card Edge Protocol,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#smart-card-edge-protocol
+37.6.8.1,EFI_SMART_CARD_EDGE_PROTOCOL,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-edge-protocol
+37.6.8.2,EFI_SMART_CARD_EDGE_PROTOCOL.GetContext(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-edge-protocol-getcontext
+37.6.8.3,EFI_SMART_CARD_EDGE_PROTOCOL. Connect(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-edge-protocol-connect
+37.6.8.4,EFI_SMART_CARD_EDGE_PROTOCOL.Disconnect(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-edge-protocol-disconnect
+37.6.8.5,EFI_SMART_CARD_EDGE_PROTOCOL.GetCsn,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-edge-protocol-getcsn
+37.6.8.6,EFI_SMART_CARD_EDGE_PROTOCOL.GetReaderName,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-edge-protocol-getreadername
+37.6.8.7,EFI_SMART_CARD_EDGE_PROTOCOL.VerifyPin(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-edge-protocol-verifypin
+37.6.8.8,EFI_SMART_CARD_EDGE_PROTOCOL.GetPinRemaining(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-edge-protocol-getpinremaining
+37.6.8.9,EFI_SMART_CARD_EDGE_PROTOCOL.GetData(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-edge-protocol-getdata
+37.6.8.10,EFI_SMART_CARD_EDGE_PROTOCOL.GetCredentials(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-edge-protocol-getcredentials
+37.6.8.11,EFI_SMART_CARD_EDGE_PROTOCOL.SignData(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-edge-protocol-signdata
+37.6.8.12,EFI_SMART_CARD_EDGE_PROTOCOL.DecryptData(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-edge-protocol-decryptdata
+37.6.8.13,EFI_SMART_CARD_EDGE_PROTOCOL.BuildDHAgreement(),https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-smart-card-edge-protocol-builddhagreement
+37.7,Memory Protection,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#memory-protection
+37.7.1,EFI_MEMORY_ATTRIBUTE PROTOCOL,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-memory-attribute-protocol
+37.7.1.1,EFI_MEMORY_ATTRIBUTE_PROTOCOL.GetMemoryAttributes,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-memory-attribute-protocol-getmemoryattributes
+37.7.1.2,EFI_MEMORY_ATTRIBUTE_PROTOCOL.SetMemoryAttributes,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-memory-attribute-protocol-setmemoryattributes
+37.7.1.3,EFI_MEMORY_ATTRIBUTE_PROTOCOL.ClearMemoryAttributes,https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-memory-attribute-protocol-clearmemoryattributes
+38,Confidential Computing,https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html
+38.1,Virtual Platform CC Event Log,https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html#virtual-platform-cc-event-log
+38.2,EFI_CC_MEASUREMENT_PROTOCOL,https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html#efi-cc-measurement-protocol
+38.2.1,EFI_CC_MEASUREMENT_PROTOCOL,https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html#id4
+38.2.2,EFI_CC_MEASUREMENT_PROTOCOL.GetCapability,https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html#efi-cc-measurement-protocol-getcapability
+38.2.3,EFI_CC_MEASUREMENT_PROTOCOL.GetEventLog,https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html#efi-cc-measurement-protocol-geteventlog
+38.2.4,EFI_CC_MEASUREMENT_PROTOCOL.HashLogExtendEvent,https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html#efi-cc-measurement-protocol-hashlogextendevent
+38.2.5,EFI_CC_MEASUREMENT_PROTOCOL.MapPcrToMrIndex,https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html#efi-cc-measurement-protocol-mappcrtomrindex
+38.3,EFI CC Final Events Table,https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html#efi-cc-final-events-table
+38.4,Vendor Specific Information,https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html#vendor-specific-information
+38.4.1,Intel Trust Domain Extension,https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html#intel-trust-domain-extension
+38.4.2,RISC-V AP-TEE,https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html#risc-v-ap-tee
+39,Miscellaneous Protocols,https://uefi.org/specs/UEFI/2.11/39_Micellaneous_Protocols.html
+39.1,EFI Timestamp Protocol,https://uefi.org/specs/UEFI/2.11/39_Micellaneous_Protocols.html#efi-timestamp-protocol
+39.1.1,EFI_TIMESTAMP_PROTOCOL,https://uefi.org/specs/UEFI/2.11/39_Micellaneous_Protocols.html#efi-timestampprotocol-micellaneous-protocols
+39.1.2,EFI_TIMESTAMP_PROTOCOL.GetTimestamp(),https://uefi.org/specs/UEFI/2.11/39_Micellaneous_Protocols.html#efi-timestamp-protocol-gettimestamp
+39.1.3,EFI_TIMESTAMP_PROTOCOL.GetProperties(),https://uefi.org/specs/UEFI/2.11/39_Micellaneous_Protocols.html#efi-timestamp-protocol-getproperties
+39.2,Reset Notification Protocol,https://uefi.org/specs/UEFI/2.11/39_Micellaneous_Protocols.html#reset-notification-protocol
+39.2.1,EFI_RESET_NOTIFICATION_PROTOCOL,https://uefi.org/specs/UEFI/2.11/39_Micellaneous_Protocols.html#efi-reset-notification-protocol
+39.2.2,EFI_RESET_NOTIFICATION_PROTOCOL.RegisterResetNotify(),https://uefi.org/specs/UEFI/2.11/39_Micellaneous_Protocols.html#efi-reset-notification-protocol-registerresetnotify
+39.2.3,EFI_RESET_NOTIFICATION_PROTOCOL.UnregisterResetNotify(),https://uefi.org/specs/UEFI/2.11/39_Micellaneous_Protocols.html#efi-reset-notification-protocol-unregisterresetnotify
+B.1,EFI_SIMPLE_TEXT_INPUT_PROTOCOL and EFI_SIMPLE_TEXT _INPUT_EX_PROTOCOL,https://uefi.org/specs/UEFI/2.11/Apx_B_Console.html#efi-simple-text-input-protocol-and-efi-simple-text-input-ex-protocol
+B.2,EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL for PC ANSI or ANSI X3.64 terminals,https://uefi.org/specs/UEFI/2.11/Apx_B_Console.html#efi-simple-text-output-protocol-for-pc-ansi-or-ansi-x3-64-terminals
+C.1,Example Computer System,https://uefi.org/specs/UEFI/2.11/Apx_C_Device_Path_Examples.html#example-computer-system
+C.2,Legacy Floppy,https://uefi.org/specs/UEFI/2.11/Apx_C_Device_Path_Examples.html#legacy-floppy
+C.3,IDE Disk,https://uefi.org/specs/UEFI/2.11/Apx_C_Device_Path_Examples.html#ide-disk
+C.4,Secondary Root PCI Bus with PCI to PCI Bridge,https://uefi.org/specs/UEFI/2.11/Apx_C_Device_Path_Examples.html#secondary-root-pci-bus-with-pci-to-pci-bridge
+C.5,ACPI Terms,https://uefi.org/specs/UEFI/2.11/Apx_C_Device_Path_Examples.html#acpi-terms
+C.6,EFI Device Path as a Name Space,https://uefi.org/specs/UEFI/2.11/Apx_C_Device_Path_Examples.html#efi-device-path-as-a-name-space
+E.1,Introduction,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#introduction
+E.1.1,Definitions,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#definitions
+E.1.2,Referenced Specifications,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#referenced-specifications
+E.1.3,OS Network Stacks,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#os-network-stacks
+E.2,Overview,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#overview
+E.2.1,32/64-bit UNDI Interface,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#bit-undi-interface
+E.2.1.1,Issuing UNDI Commands,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-undi-commands
+E.2.2,UNDI Command Format,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#undi-command-format
+E.3,UNDI C Definitions,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#undi-c-definitions
+E.3.1,Portability Macros,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#portability-macros
+E.3.1.1,PXE_INTEL_ORDER or PXE_NETWORK_ORDER,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-intel-order-or-pxe-network-order
+E.3.1.2,PXE_UINT64_SUPPORT or PXE_NO_UINT64_SUPPORT,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-uint64-support-or-pxe-no-uint64-support
+E.3.1.3,PXE_BUSTYPE,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-bustype
+E.3.1.4,PXE_SWAP_UINT16,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-swap-uint16
+E.3.1.5,PXE_SWAP_UINT32,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-swap-uint32
+E.3.1.6,PXE_SWAP_UINT64,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-swap-uint64
+E.3.2,Miscellaneous Macros,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#miscellaneous-macros
+E.3.2.1,Miscellaneous,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#miscellaneous
+E.3.3,Portability Types,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#portability-types
+E.3.3.1,PXE_CONST,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-const
+E.3.3.2,PXE_VOLATILE,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-volatile
+E.3.3.3,PXE_VOID,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-void
+E.3.3.4,PXE_UINT8,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-uint8
+E.3.3.5,PXE_UINT16,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-uint16
+E.3.3.6,PXE_UINT32,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-uint32
+E.3.3.7,PXE_UINT64,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-uint64
+E.3.3.8,PXE_UINTN,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-uintn
+E.3.4,Simple Types,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#simple-types
+E.3.4.1,PXE_BOOL,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-bool
+E.3.4.2,PXE_OPCODE,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-opcode
+E.3.4.3,PXE_OPFLAGS,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-opflags
+E.3.4.4,PXE_STATFLAGS,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-statflags
+E.3.4.5,PXE_STATCODE,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-statcode
+E.3.4.6,PXE_IFNUM,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-ifnum
+E.3.4.7,PXE_CONTROL,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-control
+E.3.4.8,PXE_FRAME_TYPE,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-frame-type
+E.3.4.9,PXE_IPV4,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-ipv4
+E.3.4.10,PXE_IPV6,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-ipv6
+E.3.4.11,PXE_MAC_ADDR,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-mac-addr
+E.3.4.12,PXE_IFTYPE,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-iftype
+E.3.4.13,PXE_MEDIA_PROTOCOL,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-media-protocol
+E.3.5,Compound Types,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#compound-types
+E.3.5.1,PXE_HW_UNDI,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-hw-undi
+E.3.5.2,PXE_SW_UNDI,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-sw-undi
+E.3.5.3,PXE_UNDI,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-undi
+E.3.5.4,PXE_CDB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-cdb
+E.3.5.5,PXE_IP_ADDR,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-ip-addr
+E.3.5.6,PXE_DEVICE,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-device
+E.4,UNDI Commands,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#undi-commands
+E.4.1,Command Linking and Queuing,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#command-linking-and-queuing
+E.4.2,Get State,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#get-state
+E.4.2.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command
+E.4.2.2,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute
+E.4.2.3,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results
+E.4.3,Start,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#start
+E.4.3.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-1
+E.4.3.2,Preparing the CPB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb
+E.4.3.3,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-1
+E.4.3.4,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-1
+E.4.4,Stop,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#stop
+E.4.4.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-2
+E.4.4.2,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-2
+E.4.4.3,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-2
+E.4.5,Get Init Info,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#get-init-info
+E.4.5.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-3
+E.4.5.2,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-3
+E.4.5.3,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-3
+E.4.5.4,StatFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#statflags
+E.4.5.5,DB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#db
+E.4.6,Get Config Info,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#get-config-info
+E.4.6.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-4
+E.4.6.2,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-4
+E.4.6.3,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-4
+E.4.6.4,DB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#db-1
+E.4.7,Initialize,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#initialize
+E.4.7.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-5
+E.4.7.2,OpFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#opflags
+E.4.7.3,Preparing the CPB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-1
+E.4.7.4,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-5
+E.4.7.5,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-5
+E.4.7.6,StatFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#statflags-1
+E.4.7.7,Before Using the DB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#before-using-the-db
+E.4.8,Reset,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#reset
+E.4.8.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-6
+E.4.8.2,OpFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-1
+E.4.8.3,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-6
+E.4.8.4,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-6
+E.4.8.5,StatFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#statflags-2
+E.4.9,Shutdown,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#shutdown
+E.4.9.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-7
+E.4.9.2,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-7
+E.4.9.3,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-7
+E.4.10,Interrupt Enables,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#interrupt-enables
+E.4.10.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-8
+E.4.10.2,OpFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-2
+E.4.10.3,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-8
+E.4.10.4,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-8
+E.4.10.5,StatFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#statflags-3
+E.4.11,Receive Filters,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#receive-filters
+E.4.11.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-9
+E.4.11.2,OpFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-3
+E.4.11.3,Preparing the CPB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-2
+E.4.11.4,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-9
+E.4.11.5,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-9
+E.4.11.6,StatFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#statflags-4
+E.4.11.7,DB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#db-2
+E.4.12,Station Address,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#station-address
+E.4.12.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-10
+E.4.12.2,OpFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-4
+E.4.12.3,Preparing the CPB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-3
+E.4.12.4,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-10
+E.4.12.5,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-10
+E.4.12.6,Before Using the DB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#before-using-the-db-1
+E.4.13,Statistics,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#statistics
+E.4.13.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-11
+E.4.13.2,OpFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-5
+E.4.13.3,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-11
+E.4.13.4,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-11
+E.4.13.5,DB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#db-3
+E.4.14,MCast IP To MAC,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#mcast-ip-to-mac
+E.4.14.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-12
+E.4.14.2,OpFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-6
+E.4.14.3,Preparing the CPB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-4
+E.4.14.4,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-12
+E.4.14.5,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-12
+E.4.14.6,Before Using the DB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#before-using-the-db-2
+E.4.15,NvData,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#nvdata
+E.4.15.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-13
+E.4.15.2,Preparing the CPB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-5
+E.4.15.3,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-13
+E.4.15.4,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-13
+E.4.16,Get Status,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#get-status
+E.4.16.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-14
+E.4.16.2,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-14
+E.4.16.3,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-14
+E.4.16.4,StatFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#statflags-5
+E.4.16.5,Using the DB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#using-the-db
+E.4.17,Fill Header,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#fill-header
+E.4.17.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-15
+E.4.17.2,OpFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-7
+E.4.17.3,Preparing the CPB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-6
+E.4.17.4,Nonfragmented Frame,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#nonfragmented-frame
+E.4.17.5,Fragmented Frame,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#fragmented-frame
+E.4.17.6,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-15
+E.4.17.7,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-15
+E.4.18,Transmit,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#transmit
+E.4.18.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-16
+E.4.18.2,OpFlags,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#opflags-8
+E.4.18.3,Preparing the CPB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-7
+E.4.18.4,Nonfragmented Frame,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#nonfragmented-frame-1
+E.4.18.5,Fragmented Frame,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#fragmented-frame-1
+E.4.18.6,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-16
+E.4.18.7,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-16
+E.4.19,Receive,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#receive
+E.4.19.1,Issuing the Command,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issuing-the-command-17
+E.4.19.2,Preparing the CPB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#preparing-the-cpb-8
+E.4.19.3,Waiting for the Command to Execute,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#waiting-for-the-command-to-execute-17
+E.4.19.4,Checking Command Execution Results,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#checking-command-execution-results-17
+E.4.19.5,Using the DB,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#using-the-db-1
+E.4.20,PXE 2.1 specification wire protocol clarifications,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#pxe-2-1-specification-wire-protocol-clarifications
+E.4.20.1,Issue #1-time-outs,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issue-1-time-outs
+E.4.20.2,Issue #2 - siaddr/option 54 precedence,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issue-2-siaddr-option-54-precedence
+E.4.20.3,Issue #3 - PXE Vendor Options Existence,https://uefi.org/specs/UEFI/2.11/Apx_E_Universal_Network_Driver_Interfaces.html#issue-3-pxe-vendor-options-existence
+L.1,Protocol and GUID Name Changes from EFI 1.10,https://uefi.org/specs/UEFI/2.11/Apx_L_EFI_1.10_Protocol_Changes_and_Deprecation_List.html#protocol-and-guid-name-changes-from-efi-1-10
+M.1,Specifying individual language codes,https://uefi.org/specs/UEFI/2.11/Apx_M_Formats_Language_Codes_and_Language_Code_Arrays.html#specifying-individual-language-codes
+M.1.1,Specifying language code arrays:,https://uefi.org/specs/UEFI/2.11/Apx_M_Formats_Language_Codes_and_Language_Code_Arrays.html#specifying-language-code-arrays
+N.1,Introduction,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#introduction
+N.2,Format,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#format
+N.2.1,Record Header,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#record-header
+N.2.1.1,Notification Type,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#notification-type
+N.2.1.2,Error Status,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#error-status
+N.2.2,Section Descriptor,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#section-descriptor
+N.2.3,Non-standard Section Body,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#non-standard-section-body
+N.2.4,Processor Error Sections,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#processor-error-sections
+N.2.4.1,Generic Processor Error Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#generic-processor-error-section
+N.2.4.2,IA32/X64 Processor Error Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#ia32-x64-processor-error-section
+N.2.4.3,IA64 Processor Error Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#ia64-processor-error-section
+N.2.4.4,ARM Processor Error Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#arm-processor-error-section
+N.2.5,Memory Error Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#memory-error-section
+N.2.6,Memory Error Section 2,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#memory-error-section-2
+N.2.7,PCI Express Error Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#pci-express-error-section
+N.2.8,PCI/PCI-X Bus Error Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#pci-pci-x-bus-error-section
+N.2.9,PCI/PCI-X Component Error Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#pci-pci-x-component-error-section
+N.2.10,Firmware Error Record Reference,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#firmware-error-record-reference
+N.2.11,DMAr Error Sections,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#dmar-error-sections
+N.2.11.1,DMAr Generic Error Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#dmar-generic-error-section
+N.2.11.2,Intel- VT for Directed I/O specific DMAr Error Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#intel-vt-for-directed-i-o-specific-dmar-error-section
+N.2.11.3,IOMMU Specific DMAr Error Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#iommu-specific-dmar-error-section
+N.2.12,CCIX PER Log Error Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#ccix-per-log-error-section
+N.2.13,Compute Express Link (CXL) Protocol Error Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#compute-express-link-cxl-protocol-error-section
+N.2.14,CXL Component Events Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#cxl-component-events-section
+N.2.15,FRU Memory Poison Section,https://uefi.org/specs/UEFI/2.11/Apx_N_Common_Platform_Error_Record.html#fru-memory-poison-section
+O.1,Invocation method,https://uefi.org/specs/UEFI/2.11/Apx_O_UEFI_ACPI_Data_Table.html#invocation-method
+P.1,Determining space,https://uefi.org/specs/UEFI/2.11/Apx_P_Hardware_Error_Record_Persistence_Usage.html#determining-space
+P.2,Saving Hardware error records,https://uefi.org/specs/UEFI/2.11/Apx_P_Hardware_Error_Record_Persistence_Usage.html#saving-hardware-error-records
+P.3,Clearing error record variables,https://uefi.org/specs/UEFI/2.11/Apx_P_Hardware_Error_Record_Persistence_Usage.html#clearing-error-record-variables
+Q.1,Related Information,https://uefi.org/specs/UEFI/2.11/Apx_Q_References.html#related-information
+Q.2,Prerequisite Specifications,https://uefi.org/specs/UEFI/2.11/Apx_Q_References.html#prerequisite-specifications
+Q.2.1,ACPI Specification,https://uefi.org/specs/UEFI/2.11/Apx_Q_References.html#acpi-specification
+Q.2.2,Additional Considerations for Itanium-BasedPlatforms,https://uefi.org/specs/UEFI/2.11/Apx_Q_References.html#additional-considerations-for-itanium-basedplatforms

--- a/source/references.rst
+++ b/source/references.rst
@@ -41,9 +41,9 @@ Bibliography
    <https://developer.arm.com/documentation/den0044/h>`_
    15 April 2024, `Arm Limited <https://www.arm.com/>`_
 
-.. [UEFI] `Unified Extensible Firmware Interface Specification v2.10 Errata A
-   <https://uefi.org/sites/default/files/resources/UEFI_Spec_2_10_A_Aug8.pdf>`_,
-   August 2024, `UEFI Forum <https://uefi.org/>`_
+.. [UEFI] `Unified Extensible Firmware Interface Specification Version 2.11
+   <https://uefi.org/sites/default/files/resources/UEFI_Spec_Final_2.11.pdf>`_,
+   December 2024, `UEFI Forum <https://uefi.org/>`_
 
 .. [RVPLTSPEC] `RISC-V Platform specification <https://github.com/riscv/riscv-platform-specs>`_
 


### PR DESCRIPTION
To follow-up with @xypron's [post on the ML](https://lists.linaro.org/archives/list/boot-architecture@lists.linaro.org/message/3HSIIFYS656Z677TSEAJ7IYGS3ZIIY4O/), update the UEFI specification version we reference to 2.11.
