### PR TITLE
All runtime services optional after ExitBootServices()

### DIFF
--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -499,10 +499,10 @@ are required to be implemented during boot services and runtime services.
      - Optional
    * - `SetVirtualAddressMap`
      - N/A
-     - Required
+     - Optional
    * - `ConvertPointer`
      - N/A
-     - Required
+     - Optional
    * - `GetVariable`
      - Required
      - Optional

--- a/source/chapter2-uefi.rst
+++ b/source/chapter2-uefi.rst
@@ -472,7 +472,7 @@ If any `EFI_RUNTIME_SERVICES` functions are only available during boot services
 then firmware shall provide the `EFI_RT_PROPERTIES_TABLE` to
 indicate which functions are available during runtime services.
 Functions that are not available during runtime services shall return
-`EFI_UNSUPPORTED`.
+`EFI_UNSUPPORTED`, as per :UEFI:`4.6.2`.
 
 :numref:`uefi_runtime_service_requirements` details which `EFI_RUNTIME_SERVICES`
 are required to be implemented during boot services and runtime services.


### PR DESCRIPTION
With this change we would have no more runtime service required after ExitBootServices().

Our requirement dates back from before UEFI version 2.8, which introduced the RT properties table and allowed the UNSUPPORTED return code for the runtime services.

This would be better aligned to what UEFI requires now. Also, making sure that we can build compliant systems with zero service at runtime is interesting for safety and realtime.