### PR TITLE
Bump references

### DIFF
--- a/source/references.rst
+++ b/source/references.rst
@@ -13,37 +13,37 @@
 Bibliography
 ************
 
-.. [ACPI] `Advanced Configuration and Power Interface specification v6.5
-   <https://uefi.org/sites/default/files/resources/ACPI_Spec_6_5_Aug29.pdf>`_,
-   August 2022, `UEFI Forum <https://uefi.org/>`_
+.. [ACPI] `Advanced Configuration and Power Interface specification v6.6
+   <https://uefi.org/sites/default/files/resources/ACPI_Spec_6.6.pdf>`_,
+   May 2025, `UEFI Forum <https://uefi.org/>`_
 
 .. [DEPBOOT] `Dependable Boot Specification version 0.1-alpha.
    <https://gitlab.com/Linaro/trustedsubstrate/mbfw/uploads/3d0d7d11ca9874dc9115616b418aa330/mbfw.pdf>`_
    November 2021, `Linaro Limited and contributors <https://www.linaro.org>`_
 
-.. [DTSCHEMA] `Devicetree schema tools v2024.09
-   <https://github.com/devicetree-org/dt-schema/releases/tag/v2024.09>`_,
+.. [DTSCHEMA] `Devicetree schema tools v2025.08
+   <https://github.com/devicetree-org/dt-schema/releases/tag/v2025.08>`_,
    `Devicetree.org <https://www.devicetree.org/>`_
 
 .. [DTSPEC] `Devicetree specification v0.4
    <https://github.com/devicetree-org/devicetree-specification/releases/tag/v0.4>`_,
    `Devicetree.org <https://www.devicetree.org/>`_
 
-.. [FFA] `Arm Firmware Framework for Arm A-profile v1.3 ALP1
-   <https://developer.arm.com/documentation/den0077/l>`_
-   November 2024, `Arm Limited <https://www.arm.com/>`_
+.. [FFA] `Arm Firmware Framework for Arm A-profile v1.3 ALP2
+   <https://developer.arm.com/documentation/den0077/m>`_
+   July 2025, `Arm Limited <https://www.arm.com/>`_
 
 .. [PSCI] `Arm Power State Coordination Interface issue F.b (PSCI v1.3).
    <https://developer.arm.com/documentation/den0022/fb>`_
    October 2024, `Arm Limited <https://www.arm.com/>`_
 
-.. [SMCCC] `SMC Calling Convention version 1.6 G (ALP1).
-   <https://developer.arm.com/documentation/den0028/galp1>`_
-   October 2024, `Arm Limited <https://www.arm.com/>`_
+.. [SMCCC] `SMC Calling Convention version 1.6 G.
+   <https://developer.arm.com/documentation/den0028/g>`_
+   July 2025, `Arm Limited <https://www.arm.com/>`_
 
-.. [ArmBBR] `Arm Base Boot Requirements specification Issue H (v2.1)
-   <https://developer.arm.com/documentation/den0044/h>`_
-   15 April 2024, `Arm Limited <https://www.arm.com/>`_
+.. [ArmBBR] `Arm Base Boot Requirements specification Issue I (v2.2)
+   <https://developer.arm.com/documentation/den0044/i>`_
+   May 2025, `Arm Limited <https://www.arm.com/>`_
 
 .. [UEFI] `Unified Extensible Firmware Interface Specification Version 2.11
    <https://uefi.org/sites/default/files/resources/UEFI_Spec_Final_2.11.pdf>`_,


### PR DESCRIPTION
Bump ACPI, dt-schema, FF-A, SMCCC and BBR versions.
AFAICT this does not necessitate any change on EBBR text.
Unless someone wants to veto this change, this should go soon.
