### PR TITLE
chapter3: raise RISC-V SBI requirement

### DIFF
--- a/source/chapter3-secureworld.rst
+++ b/source/chapter3-secureworld.rst
@@ -60,5 +60,9 @@ RISC-V Multiprocessor Startup Protocol
 ======================================
 
 The resident firmware in M mode or hypervisor running in HS mode must implement
-and conform to at least SBI [RVSBISPEC]_ v0.2 with HART State Management(HSM)
-extension for both RV32 and RV64.
+and conform to at least SBI [RVSBISPEC]_ v2.0 with at least these extensions:
+
+* Base Extension
+* HART State Management Extension (HSM)
+* System Reset Extension (SRST)
+* Debug Console Extension (DBCN) if a serial console is present


### PR DESCRIPTION
v0.2 of the RISC-V Supervisor Binary Interface Specification was a draft. We should require conformance with a ratified document.

The System Reset Extension (SRST) is needed to implement system reset and poweroff.

The Debug Console Extension (DBCN) is needed to implement an early debug console before drivers are initialized.