### PR TITLE
Mention smccc arch features in chapter3 aarch64

### DIFF
--- a/source/chapter3-secureworld.rst
+++ b/source/chapter3-secureworld.rst
@@ -44,7 +44,8 @@ It is recommended that firmware implements PSCI version 1.0 or later
    It also introduced the `PSCI_FEATURES` function, for standardized discovery.
 
 .. [#SMCCCNote] Starting with SMCCC version 1.1, support for the `SMCCC_VERSION`
-   function is required, for standardized discovery.
+   and for the `SMCCC_ARCH_FEATURES` functions is required, for standardized
+   discovery.
 
 .. warning:: A future version of this specification will require minimum PSCI
    and SMCCC versions.


### PR DESCRIPTION
Mention the SMCCC_ARCH_FEATURES function as a motivation for supporting SMCCC >= 1.1.

This is informative only, no requirement change.